### PR TITLE
Add `#[repr(C)]` on a few remaining `blst` types

### DIFF
--- a/blst/src/types/fr.rs
+++ b/blst/src/types/fr.rs
@@ -14,6 +14,7 @@ use kzg::eip_4844::BYTES_PER_FIELD_ELEMENT;
 use kzg::Fr;
 use kzg::Scalar256;
 
+#[repr(C)]
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
 pub struct FsFr(pub blst_fr);
 

--- a/blst/src/types/g2.rs
+++ b/blst/src/types/g2.rs
@@ -17,6 +17,7 @@ use kzg::{G2Mul, G2};
 use crate::consts::{G2_GENERATOR, G2_NEGATIVE_GENERATOR};
 use crate::types::fr::FsFr;
 
+#[repr(C)]
 #[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
 pub struct FsG2(pub blst_p2);
 


### PR DESCRIPTION
Other types had `#[repr(C)]` on them already. This is important for FFI purposes.