### PR TITLE
Optionally disable c bindings

### DIFF
--- a/arkworks/Cargo.toml
+++ b/arkworks/Cargo.toml
@@ -27,7 +27,6 @@ default = [
     "std",
     "rand",
     "bgmw",
-    "c_bindings"
 ]
 std = [
     "ark-ff/std", "ark-ec/std", "ark-poly/std", "ark-std/std", 

--- a/arkworks/Cargo.toml
+++ b/arkworks/Cargo.toml
@@ -26,7 +26,8 @@ rand = { version = "0.8.5" }
 default = [
     "std",
     "rand",
-    "bgmw"
+    "bgmw",
+    "c_bindings"
 ]
 std = [
     "ark-ff/std", "ark-ec/std", "ark-poly/std", "ark-std/std", 
@@ -47,6 +48,7 @@ bgmw = [
 arkmsm = [
     "kzg/arkmsm"
 ]
+c_bindings = []
 
 [[bench]]
 name = "fft"

--- a/arkworks/src/eip_4844.rs
+++ b/arkworks/src/eip_4844.rs
@@ -1,7 +1,9 @@
 extern crate alloc;
 
 use crate::kzg_proofs::KZGSettings as LKZGSettings;
+#[cfg(feature = "c_bindings")]
 use crate::utils::PRECOMPUTATION_TABLES;
+#[cfg(feature = "c_bindings")]
 use kzg::{
     eth::{
         self,
@@ -10,13 +12,14 @@ use kzg::{
     Fr, G1,
 };
 
-#[cfg(feature = "std")]
+#[cfg(feature = "c_bindings")]
+use core::ptr;
+#[cfg(all(feature = "std", feature = "c_bindings"))]
 use libc::FILE;
 #[cfg(feature = "std")]
 use std::fs::File;
 #[cfg(feature = "std")]
 use std::io::Read;
-use std::ptr;
 
 #[cfg(feature = "std")]
 use kzg::eip_4844::load_trusted_setup_string;
@@ -37,6 +40,7 @@ pub fn load_trusted_setup_filename_rust(
     load_trusted_setup_rust(&g1_monomial_bytes, &g1_lagrange_bytes, &g2_monomial_bytes)
 }
 
+#[cfg(feature = "c_bindings")]
 pub(crate) fn kzg_settings_to_c(rust_settings: &LKZGSettings) -> CKZGSettings {
     CKZGSettings {
         roots_of_unity: Box::leak(
@@ -119,6 +123,7 @@ pub(crate) fn kzg_settings_to_c(rust_settings: &LKZGSettings) -> CKZGSettings {
     }
 }
 
+#[cfg(feature = "c_bindings")]
 macro_rules! handle_ckzg_badargs {
     ($x: expr) => {
         match $x {

--- a/arkworks/src/eip_7594.rs
+++ b/arkworks/src/eip_7594.rs
@@ -2,8 +2,6 @@ extern crate alloc;
 
 use kzg::EcBackend;
 
-use kzg::c_bindings_eip7594;
-
 use crate::kzg_proofs::FFTSettings;
 use crate::kzg_proofs::KZGSettings;
 use crate::kzg_types::ArkFp;
@@ -26,4 +24,5 @@ impl EcBackend for ArkBackend {
     type KZGSettings = KZGSettings;
 }
 
-c_bindings_eip7594!(ArkBackend);
+#[cfg(feature = "c_bindings")]
+kzg::c_bindings_eip7594!(ArkBackend);

--- a/arkworks/src/utils.rs
+++ b/arkworks/src/utils.rs
@@ -9,10 +9,10 @@ use ark_poly::univariate::DensePolynomial as DensePoly;
 use ark_poly::DenseUVPolynomial;
 use blst::{blst_fp, blst_fp2, blst_fr, blst_p1, blst_p2};
 
-use kzg::eip_4844::{PrecomputationTableManager, BYTES_PER_FIELD_ELEMENT};
-use kzg::eth::c_bindings::{Blob, CKZGSettings, CKzgRet};
+use kzg::eip_4844::PrecomputationTableManager;
+use kzg::eth::c_bindings::CKZGSettings;
 
-use kzg::{eth, Fr};
+use kzg::eth;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Error;
@@ -113,22 +113,6 @@ pub const fn pc_g2projective_into_blst_p2(p2: Projective<g2::Config>) -> blst_p2
             ],
         },
     }
-}
-
-pub(crate) unsafe fn deserialize_blob(blob: *const Blob) -> Result<Vec<ArkFr>, CKzgRet> {
-    (*blob)
-        .bytes
-        .chunks(BYTES_PER_FIELD_ELEMENT)
-        .map(|chunk| {
-            let mut bytes = [0u8; BYTES_PER_FIELD_ELEMENT];
-            bytes.copy_from_slice(chunk);
-            if let Ok(result) = ArkFr::from_bytes(&bytes) {
-                Ok(result)
-            } else {
-                Err(CKzgRet::BadArgs)
-            }
-        })
-        .collect::<Result<Vec<ArkFr>, CKzgRet>>()
 }
 
 pub(crate) fn fft_settings_to_rust(c_settings: *const CKZGSettings) -> Result<FFTSettings, String> {

--- a/arkworks3/Cargo.toml
+++ b/arkworks3/Cargo.toml
@@ -28,7 +28,6 @@ rand = { version = "0.8.5" }
 default = [
     "std",
     "rand",
-    "c_bindings"
 ]
 std = [
     "ark-ff/std", "ark-ec/std", "ark-poly/std", "ark-std/std", 

--- a/arkworks3/Cargo.toml
+++ b/arkworks3/Cargo.toml
@@ -27,7 +27,8 @@ rand = { version = "0.8.5" }
 [features]
 default = [
     "std",
-    "rand"
+    "rand",
+    "c_bindings"
 ]
 std = [
     "ark-ff/std", "ark-ec/std", "ark-poly/std", "ark-std/std", 
@@ -50,6 +51,7 @@ sppark_wlc = [
     "dep:rust-kzg-arkworks3-sppark-wlc",
     "kzg/sppark"
 ]
+c_bindings = []
 
 [[bench]]
 name = "fft"

--- a/arkworks3/src/eip_4844.rs
+++ b/arkworks3/src/eip_4844.rs
@@ -1,24 +1,33 @@
 extern crate alloc;
 
 use crate::kzg_proofs::KZGSettings;
+#[cfg(feature = "c_bindings")]
+use alloc::boxed::Box;
+#[cfg(feature = "c_bindings")]
 use core::ptr;
-use kzg::eip_4844::{
-    load_trusted_setup_rust, BYTES_PER_G1, FIELD_ELEMENTS_PER_BLOB, TRUSTED_SETUP_NUM_G1_POINTS,
-    TRUSTED_SETUP_NUM_G2_POINTS,
+use kzg::eip_4844::load_trusted_setup_rust;
+#[cfg(feature = "c_bindings")]
+use kzg::{
+    eip_4844::{
+        BYTES_PER_G1, FIELD_ELEMENTS_PER_BLOB, TRUSTED_SETUP_NUM_G1_POINTS,
+        TRUSTED_SETUP_NUM_G2_POINTS,
+    },
+    eth::{
+        self,
+        c_bindings::{Blob, Bytes32, Bytes48, CKZGSettings, CKzgRet, KZGCommitment, KZGProof},
+    },
+    Fr, G1,
 };
-use kzg::eth::c_bindings::{
-    Blob, Bytes32, Bytes48, CKZGSettings, CKzgRet, KZGCommitment, KZGProof,
-};
-use kzg::{eth, Fr, G1};
 
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", feature = "c_bindings"))]
 use libc::FILE;
 #[cfg(feature = "std")]
 use std::fs::File;
 #[cfg(feature = "std")]
 use std::io::Read;
 
-use crate::utils::{handle_ckzg_badargs, kzg_settings_to_c, PRECOMPUTATION_TABLES};
+#[cfg(feature = "c_bindings")]
+use crate::utils::PRECOMPUTATION_TABLES;
 
 #[cfg(feature = "std")]
 use kzg::eip_4844::load_trusted_setup_string;
@@ -35,6 +44,99 @@ pub fn load_trusted_setup_filename_rust(
     let (g1_monomial_bytes, g1_lagrange_bytes, g2_monomial_bytes) =
         load_trusted_setup_string(&contents)?;
     load_trusted_setup_rust(&g1_monomial_bytes, &g1_lagrange_bytes, &g2_monomial_bytes)
+}
+
+#[cfg(feature = "c_bindings")]
+macro_rules! handle_ckzg_badargs {
+    ($x: expr) => {
+        match $x {
+            Ok(value) => value,
+            Err(_) => return kzg::eth::c_bindings::CKzgRet::BadArgs,
+        }
+    };
+}
+
+#[cfg(feature = "c_bindings")]
+fn kzg_settings_to_c(rust_settings: &KZGSettings) -> CKZGSettings {
+    CKZGSettings {
+        roots_of_unity: Box::leak(
+            rust_settings
+                .fs
+                .roots_of_unity
+                .iter()
+                .map(|r| r.to_blst_fr())
+                .collect::<Vec<_>>()
+                .into_boxed_slice(),
+        )
+        .as_mut_ptr(),
+        brp_roots_of_unity: Box::leak(
+            rust_settings
+                .fs
+                .brp_roots_of_unity
+                .iter()
+                .map(|r| r.to_blst_fr())
+                .collect::<Vec<_>>()
+                .into_boxed_slice(),
+        )
+        .as_mut_ptr(),
+        reverse_roots_of_unity: Box::leak(
+            rust_settings
+                .fs
+                .reverse_roots_of_unity
+                .iter()
+                .map(|r| r.to_blst_fr())
+                .collect::<Vec<_>>()
+                .into_boxed_slice(),
+        )
+        .as_mut_ptr(),
+        g1_values_monomial: Box::leak(
+            rust_settings
+                .g1_values_monomial
+                .iter()
+                .map(|r| r.to_blst_p1())
+                .collect::<Vec<_>>()
+                .into_boxed_slice(),
+        )
+        .as_mut_ptr(),
+        g1_values_lagrange_brp: Box::leak(
+            rust_settings
+                .g1_values_lagrange_brp
+                .iter()
+                .map(|r| r.to_blst_p1())
+                .collect::<Vec<_>>()
+                .into_boxed_slice(),
+        )
+        .as_mut_ptr(),
+        g2_values_monomial: Box::leak(
+            rust_settings
+                .g2_values_monomial
+                .iter()
+                .map(|r| r.to_blst_p2())
+                .collect::<Vec<_>>()
+                .into_boxed_slice(),
+        )
+        .as_mut_ptr(),
+        x_ext_fft_columns: Box::leak(
+            rust_settings
+                .x_ext_fft_columns
+                .iter()
+                .map(|r| {
+                    Box::leak(
+                        r.iter()
+                            .map(|it| it.to_blst_p1())
+                            .collect::<Vec<_>>()
+                            .into_boxed_slice(),
+                    )
+                    .as_mut_ptr()
+                })
+                .collect::<Vec<_>>()
+                .into_boxed_slice(),
+        )
+        .as_mut_ptr(),
+        tables: core::ptr::null_mut(),
+        wbits: 0,
+        scratch_size: 0,
+    }
 }
 
 /// # Safety

--- a/arkworks3/src/eip_4844.rs
+++ b/arkworks3/src/eip_4844.rs
@@ -1,18 +1,15 @@
 extern crate alloc;
 
 use crate::kzg_proofs::KZGSettings;
-use crate::kzg_types::{ArkFr, ArkG1};
 use core::ptr;
 use kzg::eip_4844::{
-    blob_to_kzg_commitment_rust, compute_blob_kzg_proof_rust, compute_kzg_proof_rust,
-    load_trusted_setup_rust, verify_blob_kzg_proof_batch_rust, verify_blob_kzg_proof_rust,
-    verify_kzg_proof_rust, BYTES_PER_G1, FIELD_ELEMENTS_PER_BLOB, TRUSTED_SETUP_NUM_G1_POINTS,
+    load_trusted_setup_rust, BYTES_PER_G1, FIELD_ELEMENTS_PER_BLOB, TRUSTED_SETUP_NUM_G1_POINTS,
     TRUSTED_SETUP_NUM_G2_POINTS,
 };
 use kzg::eth::c_bindings::{
     Blob, Bytes32, Bytes48, CKZGSettings, CKzgRet, KZGCommitment, KZGProof,
 };
-use kzg::{cfg_into_iter, eth, Fr, G1};
+use kzg::{eth, Fr, G1};
 
 #[cfg(feature = "std")]
 use libc::FILE;
@@ -21,12 +18,7 @@ use std::fs::File;
 #[cfg(feature = "std")]
 use std::io::Read;
 
-use crate::utils::{
-    deserialize_blob, handle_ckzg_badargs, kzg_settings_to_c, PRECOMPUTATION_TABLES,
-};
-
-#[cfg(feature = "parallel")]
-use rayon::prelude::*;
+use crate::utils::{handle_ckzg_badargs, kzg_settings_to_c, PRECOMPUTATION_TABLES};
 
 #[cfg(feature = "std")]
 use kzg::eip_4844::load_trusted_setup_string;
@@ -46,26 +38,29 @@ pub fn load_trusted_setup_filename_rust(
 }
 
 /// # Safety
+#[cfg(feature = "c_bindings")]
 #[no_mangle]
 pub unsafe extern "C" fn blob_to_kzg_commitment(
     out: *mut KZGCommitment,
     blob: *const Blob,
     s: &CKZGSettings,
 ) -> CKzgRet {
+    use kzg::eip_4844::blob_to_kzg_commitment_raw;
+
     if TRUSTED_SETUP_NUM_G1_POINTS == 0 {
         // FIXME: load_trusted_setup should set this value, but if not, it fails
         TRUSTED_SETUP_NUM_G1_POINTS = FIELD_ELEMENTS_PER_BLOB
     };
 
-    let deserialized_blob = handle_ckzg_badargs!(deserialize_blob(blob));
     let settings: KZGSettings = handle_ckzg_badargs!(s.try_into());
-    let tmp = handle_ckzg_badargs!(blob_to_kzg_commitment_rust(&deserialized_blob, &settings));
+    let tmp = handle_ckzg_badargs!(blob_to_kzg_commitment_raw((*blob).bytes, &settings));
 
     (*out).bytes = tmp.to_bytes();
     CKzgRet::Ok
 }
 
 /// # Safety
+#[cfg(feature = "c_bindings")]
 #[no_mangle]
 pub unsafe extern "C" fn load_trusted_setup(
     out: *mut CKZGSettings,
@@ -112,7 +107,7 @@ pub unsafe extern "C" fn load_trusted_setup(
 }
 
 /// # Safety
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", feature = "c_bindings"))]
 #[no_mangle]
 pub unsafe extern "C" fn load_trusted_setup_file(
     out: *mut CKZGSettings,
@@ -159,6 +154,7 @@ pub unsafe extern "C" fn load_trusted_setup_file(
 }
 
 /// # Safety
+#[cfg(feature = "c_bindings")]
 #[no_mangle]
 pub unsafe extern "C" fn free_trusted_setup(s: *mut CKZGSettings) {
     if s.is_null() {
@@ -245,6 +241,7 @@ pub unsafe extern "C" fn free_trusted_setup(s: *mut CKZGSettings) {
 }
 
 /// # Safety
+#[cfg(feature = "c_bindings")]
 #[no_mangle]
 pub unsafe extern "C" fn verify_kzg_proof(
     ok: *mut bool,
@@ -254,18 +251,15 @@ pub unsafe extern "C" fn verify_kzg_proof(
     proof_bytes: *const Bytes48,
     s: &CKZGSettings,
 ) -> CKzgRet {
-    let frz = handle_ckzg_badargs!(ArkFr::from_bytes(&(*z_bytes).bytes));
-    let fry = handle_ckzg_badargs!(ArkFr::from_bytes(&(*y_bytes).bytes));
-    let g1commitment = handle_ckzg_badargs!(ArkG1::from_bytes(&(*commitment_bytes).bytes));
-    let g1proof = handle_ckzg_badargs!(ArkG1::from_bytes(&(*proof_bytes).bytes));
+    use kzg::eip_4844::verify_kzg_proof_raw;
 
     let settings: KZGSettings = handle_ckzg_badargs!(s.try_into());
 
-    let result = handle_ckzg_badargs!(verify_kzg_proof_rust(
-        &g1commitment,
-        &frz,
-        &fry,
-        &g1proof,
+    let result = handle_ckzg_badargs!(verify_kzg_proof_raw(
+        (*commitment_bytes).bytes,
+        (*z_bytes).bytes,
+        (*y_bytes).bytes,
+        (*proof_bytes).bytes,
         &settings
     ));
 
@@ -274,6 +268,7 @@ pub unsafe extern "C" fn verify_kzg_proof(
 }
 
 /// # Safety
+#[cfg(feature = "c_bindings")]
 #[no_mangle]
 pub unsafe extern "C" fn verify_blob_kzg_proof(
     ok: *mut bool,
@@ -282,17 +277,14 @@ pub unsafe extern "C" fn verify_blob_kzg_proof(
     proof_bytes: *const Bytes48,
     s: &CKZGSettings,
 ) -> CKzgRet {
-    let deserialized_blob = handle_ckzg_badargs!(deserialize_blob(blob));
-
-    let commitment_g1 = handle_ckzg_badargs!(ArkG1::from_bytes(&(*commitment_bytes).bytes));
-    let proof_g1 = handle_ckzg_badargs!(ArkG1::from_bytes(&(*proof_bytes).bytes));
+    use kzg::eip_4844::verify_blob_kzg_proof_raw;
 
     let settings: KZGSettings = handle_ckzg_badargs!(s.try_into());
 
-    let result = handle_ckzg_badargs!(verify_blob_kzg_proof_rust(
-        &deserialized_blob,
-        &commitment_g1,
-        &proof_g1,
+    let result = handle_ckzg_badargs!(verify_blob_kzg_proof_raw(
+        (*blob).bytes,
+        (*commitment_bytes).bytes,
+        (*proof_bytes).bytes,
         &settings,
     ));
 
@@ -301,6 +293,7 @@ pub unsafe extern "C" fn verify_blob_kzg_proof(
 }
 
 /// # Safety
+#[cfg(feature = "c_bindings")]
 #[no_mangle]
 pub unsafe extern "C" fn verify_blob_kzg_proof_batch(
     ok: *mut bool,
@@ -310,45 +303,38 @@ pub unsafe extern "C" fn verify_blob_kzg_proof_batch(
     n: usize,
     s: &CKZGSettings,
 ) -> CKzgRet {
-    let raw_blobs = core::slice::from_raw_parts(blobs, n);
-    let raw_commitments = core::slice::from_raw_parts(commitments_bytes, n);
-    let raw_proofs = core::slice::from_raw_parts(proofs_bytes, n);
+    use kzg::eip_4844::verify_blob_kzg_proof_batch_raw;
 
-    let deserialized_blobs: Result<Vec<Vec<ArkFr>>, CKzgRet> = cfg_into_iter!(raw_blobs)
-        .map(|raw_blob| deserialize_blob(raw_blob).map_err(|_| CKzgRet::BadArgs))
-        .collect();
+    let blobs = core::slice::from_raw_parts(blobs, n)
+        .iter()
+        .map(|b| b.bytes)
+        .collect::<Vec<_>>();
+    let commitments = core::slice::from_raw_parts(commitments_bytes, n)
+        .iter()
+        .map(|b| b.bytes)
+        .collect::<Vec<_>>();
+    let proofs = core::slice::from_raw_parts(proofs_bytes, n)
+        .iter()
+        .map(|b| b.bytes)
+        .collect::<Vec<_>>();
 
-    let commitments_g1: Result<Vec<ArkG1>, CKzgRet> = cfg_into_iter!(raw_commitments)
-        .map(|raw_commitment| {
-            ArkG1::from_bytes(&raw_commitment.bytes).map_err(|_| CKzgRet::BadArgs)
-        })
-        .collect();
+    *ok = false;
 
-    let proofs_g1: Result<Vec<ArkG1>, CKzgRet> = cfg_into_iter!(raw_proofs)
-        .map(|raw_proof| ArkG1::from_bytes(&raw_proof.bytes).map_err(|_| CKzgRet::BadArgs))
-        .collect();
+    let settings: KZGSettings = handle_ckzg_badargs!(s.try_into());
 
-    if let (Ok(blobs), Ok(commitments), Ok(proofs)) =
-        (deserialized_blobs, commitments_g1, proofs_g1)
-    {
-        let settings: KZGSettings = handle_ckzg_badargs!(s.try_into());
+    let result = handle_ckzg_badargs!(verify_blob_kzg_proof_batch_raw(
+        &blobs,
+        &commitments,
+        &proofs,
+        &settings
+    ));
 
-        let result =
-            verify_blob_kzg_proof_batch_rust(blobs.as_slice(), &commitments, &proofs, &settings);
-
-        if let Ok(result) = result {
-            *ok = result;
-            CKzgRet::Ok
-        } else {
-            CKzgRet::BadArgs
-        }
-    } else {
-        *ok = false;
-        CKzgRet::BadArgs
-    }
+    *ok = result;
+    CKzgRet::Ok
 }
 
 /// # Safety
+#[cfg(feature = "c_bindings")]
 #[no_mangle]
 pub unsafe extern "C" fn compute_blob_kzg_proof(
     out: *mut KZGProof,
@@ -356,16 +342,12 @@ pub unsafe extern "C" fn compute_blob_kzg_proof(
     commitment_bytes: *const Bytes48,
     s: &CKZGSettings,
 ) -> CKzgRet {
-    let deserialized_blob = match deserialize_blob(blob) {
-        Ok(value) => value,
-        Err(err) => return err,
-    };
+    use kzg::eip_4844::compute_blob_kzg_proof_raw;
 
-    let commitment_g1 = handle_ckzg_badargs!(ArkG1::from_bytes(&(*commitment_bytes).bytes));
     let settings: KZGSettings = handle_ckzg_badargs!(s.try_into());
-    let proof = handle_ckzg_badargs!(compute_blob_kzg_proof_rust(
-        &deserialized_blob,
-        &commitment_g1,
+    let proof = handle_ckzg_badargs!(compute_blob_kzg_proof_raw(
+        (*blob).bytes,
+        (*commitment_bytes).bytes,
         &settings
     ));
 
@@ -374,6 +356,7 @@ pub unsafe extern "C" fn compute_blob_kzg_proof(
 }
 
 /// # Safety
+#[cfg(feature = "c_bindings")]
 #[no_mangle]
 pub unsafe extern "C" fn compute_kzg_proof(
     proof_out: *mut KZGProof,
@@ -382,17 +365,15 @@ pub unsafe extern "C" fn compute_kzg_proof(
     z_bytes: *const Bytes32,
     s: &CKZGSettings,
 ) -> CKzgRet {
-    let deserialized_blob = match deserialize_blob(blob) {
-        Ok(value) => value,
-        Err(err) => return err,
-    };
-
-    let frz = handle_ckzg_badargs!(ArkFr::from_bytes(&(*z_bytes).bytes));
+    use kzg::eip_4844::compute_kzg_proof_raw;
 
     let settings: KZGSettings = handle_ckzg_badargs!(s.try_into());
 
-    let (proof_out_tmp, fry_tmp) =
-        handle_ckzg_badargs!(compute_kzg_proof_rust(&deserialized_blob, &frz, &settings));
+    let (proof_out_tmp, fry_tmp) = handle_ckzg_badargs!(compute_kzg_proof_raw(
+        (*blob).bytes,
+        (*z_bytes).bytes,
+        &settings
+    ));
 
     (*proof_out).bytes = proof_out_tmp.to_bytes();
     (*y_out).bytes = fry_tmp.to_bytes();

--- a/arkworks3/src/eip_7594.rs
+++ b/arkworks3/src/eip_7594.rs
@@ -2,8 +2,6 @@ extern crate alloc;
 
 use kzg::EcBackend;
 
-use kzg::c_bindings_eip7594;
-
 use crate::kzg_proofs::FFTSettings;
 use crate::kzg_proofs::KZGSettings;
 use crate::kzg_types::ArkFp;
@@ -26,4 +24,5 @@ impl EcBackend for ArkBackend {
     type KZGSettings = KZGSettings;
 }
 
-c_bindings_eip7594!(ArkBackend);
+#[cfg(feature = "c_bindings")]
+kzg::c_bindings_eip7594!(ArkBackend);

--- a/arkworks3/src/utils.rs
+++ b/arkworks3/src/utils.rs
@@ -3,12 +3,8 @@ extern crate alloc;
 use alloc::boxed::Box;
 
 use kzg::{
-    eip_4844::{PrecomputationTableManager, BYTES_PER_FIELD_ELEMENT},
-    eth::{
-        self,
-        c_bindings::{Blob, CKZGSettings, CKzgRet},
-    },
-    Fr,
+    eip_4844::PrecomputationTableManager,
+    eth::{self, c_bindings::CKZGSettings},
 };
 
 use crate::kzg_proofs::{FFTSettings as LFFTSettings, KZGSettings as LKZGSettings};
@@ -31,22 +27,6 @@ pub struct PolyData {
     pub coeffs: Vec<ArkFr>,
 }
 // FIXME: Store just dense poly here
-
-pub(crate) unsafe fn deserialize_blob(blob: *const Blob) -> Result<Vec<ArkFr>, CKzgRet> {
-    (*blob)
-        .bytes
-        .chunks(BYTES_PER_FIELD_ELEMENT)
-        .map(|chunk| {
-            let mut bytes = [0u8; BYTES_PER_FIELD_ELEMENT];
-            bytes.copy_from_slice(chunk);
-            if let Ok(result) = ArkFr::from_bytes(&bytes) {
-                Ok(result)
-            } else {
-                Err(CKzgRet::BadArgs)
-            }
-        })
-        .collect::<Result<Vec<ArkFr>, CKzgRet>>()
-}
 
 macro_rules! handle_ckzg_badargs {
     ($x: expr) => {

--- a/blst/Cargo.toml
+++ b/blst/Cargo.toml
@@ -24,7 +24,6 @@ default = [
     "std",
     "rand",
     "bgmw",
-    "c_bindings",
 ]
 std = [
     "hex/std",

--- a/blst/Cargo.toml
+++ b/blst/Cargo.toml
@@ -23,7 +23,8 @@ rand = "0.8.5"
 default = [
     "std",
     "rand",
-    "bgmw"
+    "bgmw",
+    "c_bindings",
 ]
 std = [
     "hex/std",
@@ -49,6 +50,7 @@ sppark = [
     "dep:rust-kzg-blst-sppark",
     "kzg/sppark"
 ]
+c_bindings = []
 
 [[bench]]
 name = "das"

--- a/blst/src/eip_4844.rs
+++ b/blst/src/eip_4844.rs
@@ -4,16 +4,14 @@ use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::ptr;
 use kzg::eip_4844::{
-    blob_to_kzg_commitment_rust, compute_blob_kzg_proof_rust, compute_kzg_proof_rust,
-    load_trusted_setup_rust, verify_blob_kzg_proof_batch_rust, verify_blob_kzg_proof_rust,
-    verify_kzg_proof_rust, BYTES_PER_G1, FIELD_ELEMENTS_PER_BLOB, TRUSTED_SETUP_NUM_G1_POINTS,
+    load_trusted_setup_rust, BYTES_PER_G1, FIELD_ELEMENTS_PER_BLOB, TRUSTED_SETUP_NUM_G1_POINTS,
     TRUSTED_SETUP_NUM_G2_POINTS,
 };
 use kzg::eth::c_bindings::{
     Blob, Bytes32, Bytes48, CKZGSettings, CKzgRet, KZGCommitment, KZGProof,
 };
 use kzg::eth::{FIELD_ELEMENTS_PER_CELL, FIELD_ELEMENTS_PER_EXT_BLOB};
-use kzg::{cfg_into_iter, Fr, G1};
+use kzg::{Fr, G1};
 #[cfg(feature = "std")]
 use libc::FILE;
 #[cfg(feature = "std")]
@@ -24,16 +22,8 @@ use std::io::Read;
 #[cfg(feature = "std")]
 use kzg::eip_4844::load_trusted_setup_string;
 
-use crate::types::fr::FsFr;
-
-use crate::types::g1::FsG1;
 use crate::types::kzg_settings::FsKZGSettings;
-use crate::utils::{
-    deserialize_blob, handle_ckzg_badargs, kzg_settings_to_c, PRECOMPUTATION_TABLES,
-};
-
-#[cfg(feature = "parallel")]
-use rayon::prelude::*;
+use crate::utils::{handle_ckzg_badargs, kzg_settings_to_c, PRECOMPUTATION_TABLES};
 
 #[cfg(feature = "std")]
 pub fn load_trusted_setup_filename_rust(
@@ -50,26 +40,24 @@ pub fn load_trusted_setup_filename_rust(
 }
 
 /// # Safety
+#[cfg(feature = "c_bindings")]
 #[no_mangle]
 pub unsafe extern "C" fn blob_to_kzg_commitment(
     out: *mut KZGCommitment,
     blob: *const Blob,
     s: &CKZGSettings,
 ) -> CKzgRet {
-    if TRUSTED_SETUP_NUM_G1_POINTS == 0 {
-        // FIXME: load_trusted_setup should set this value, but if not, it fails
-        TRUSTED_SETUP_NUM_G1_POINTS = FIELD_ELEMENTS_PER_BLOB
-    };
+    use kzg::eip_4844::blob_to_kzg_commitment_raw;
 
-    let deserialized_blob = handle_ckzg_badargs!(deserialize_blob(blob));
     let settings: FsKZGSettings = handle_ckzg_badargs!(s.try_into());
-    let tmp = handle_ckzg_badargs!(blob_to_kzg_commitment_rust(&deserialized_blob, &settings));
+    let result = handle_ckzg_badargs!(blob_to_kzg_commitment_raw((*blob).bytes, &settings));
+    (*out).bytes = result.to_bytes();
 
-    (*out).bytes = tmp.to_bytes();
     CKzgRet::Ok
 }
 
 /// # Safety
+#[cfg(feature = "c_bindings")]
 #[no_mangle]
 pub unsafe extern "C" fn load_trusted_setup(
     out: *mut CKZGSettings,
@@ -116,7 +104,7 @@ pub unsafe extern "C" fn load_trusted_setup(
 }
 
 /// # Safety
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", feature = "c_bindings"))]
 #[no_mangle]
 pub unsafe extern "C" fn load_trusted_setup_file(
     out: *mut CKZGSettings,
@@ -163,6 +151,7 @@ pub unsafe extern "C" fn load_trusted_setup_file(
 }
 
 /// # Safety
+#[cfg(feature = "c_bindings")]
 #[no_mangle]
 pub unsafe extern "C" fn compute_blob_kzg_proof(
     out: *mut KZGProof,
@@ -170,16 +159,12 @@ pub unsafe extern "C" fn compute_blob_kzg_proof(
     commitment_bytes: *const Bytes48,
     s: &CKZGSettings,
 ) -> CKzgRet {
-    let deserialized_blob = match deserialize_blob(blob) {
-        Ok(value) => value,
-        Err(err) => return err,
-    };
+    use kzg::eip_4844::compute_blob_kzg_proof_raw;
 
-    let commitment_g1 = handle_ckzg_badargs!(FsG1::from_bytes(&(*commitment_bytes).bytes));
     let settings: FsKZGSettings = handle_ckzg_badargs!(s.try_into());
-    let proof = handle_ckzg_badargs!(compute_blob_kzg_proof_rust(
-        &deserialized_blob,
-        &commitment_g1,
+    let proof = handle_ckzg_badargs!(compute_blob_kzg_proof_raw(
+        (*blob).bytes,
+        (*commitment_bytes).bytes,
         &settings
     ));
 
@@ -188,6 +173,7 @@ pub unsafe extern "C" fn compute_blob_kzg_proof(
 }
 
 /// # Safety
+#[cfg(feature = "c_bindings")]
 #[no_mangle]
 pub unsafe extern "C" fn free_trusted_setup(s: *mut CKZGSettings) {
     if s.is_null() {
@@ -274,6 +260,7 @@ pub unsafe extern "C" fn free_trusted_setup(s: *mut CKZGSettings) {
 }
 
 /// # Safety
+#[cfg(feature = "c_bindings")]
 #[no_mangle]
 pub unsafe extern "C" fn verify_kzg_proof(
     ok: *mut bool,
@@ -283,18 +270,15 @@ pub unsafe extern "C" fn verify_kzg_proof(
     proof_bytes: *const Bytes48,
     s: &CKZGSettings,
 ) -> CKzgRet {
-    let frz = handle_ckzg_badargs!(FsFr::from_bytes(&(*z_bytes).bytes));
-    let fry = handle_ckzg_badargs!(FsFr::from_bytes(&(*y_bytes).bytes));
-    let g1commitment = handle_ckzg_badargs!(FsG1::from_bytes(&(*commitment_bytes).bytes));
-    let g1proof = handle_ckzg_badargs!(FsG1::from_bytes(&(*proof_bytes).bytes));
+    use kzg::eip_4844::verify_kzg_proof_raw;
 
     let settings: FsKZGSettings = handle_ckzg_badargs!(s.try_into());
 
-    let result = handle_ckzg_badargs!(verify_kzg_proof_rust(
-        &g1commitment,
-        &frz,
-        &fry,
-        &g1proof,
+    let result = handle_ckzg_badargs!(verify_kzg_proof_raw(
+        (*commitment_bytes).bytes,
+        (*z_bytes).bytes,
+        (*y_bytes).bytes,
+        (*proof_bytes).bytes,
         &settings
     ));
 
@@ -303,6 +287,7 @@ pub unsafe extern "C" fn verify_kzg_proof(
 }
 
 /// # Safety
+#[cfg(feature = "c_bindings")]
 #[no_mangle]
 pub unsafe extern "C" fn verify_blob_kzg_proof(
     ok: *mut bool,
@@ -311,15 +296,14 @@ pub unsafe extern "C" fn verify_blob_kzg_proof(
     proof_bytes: *const Bytes48,
     s: &CKZGSettings,
 ) -> CKzgRet {
-    let deserialized_blob = handle_ckzg_badargs!(deserialize_blob(blob));
-    let commitment_g1 = handle_ckzg_badargs!(FsG1::from_bytes(&(*commitment_bytes).bytes));
-    let proof_g1 = handle_ckzg_badargs!(FsG1::from_bytes(&(*proof_bytes).bytes));
+    use kzg::eip_4844::verify_blob_kzg_proof_raw;
+
     let settings: FsKZGSettings = handle_ckzg_badargs!(s.try_into());
 
-    let result = handle_ckzg_badargs!(verify_blob_kzg_proof_rust(
-        &deserialized_blob,
-        &commitment_g1,
-        &proof_g1,
+    let result = handle_ckzg_badargs!(verify_blob_kzg_proof_raw(
+        (*blob).bytes,
+        (*commitment_bytes).bytes,
+        (*proof_bytes).bytes,
         &settings,
     ));
 
@@ -328,6 +312,7 @@ pub unsafe extern "C" fn verify_blob_kzg_proof(
 }
 
 /// # Safety
+#[cfg(feature = "c_bindings")]
 #[no_mangle]
 pub unsafe extern "C" fn verify_blob_kzg_proof_batch(
     ok: *mut bool,
@@ -337,46 +322,38 @@ pub unsafe extern "C" fn verify_blob_kzg_proof_batch(
     n: usize,
     s: &CKZGSettings,
 ) -> CKzgRet {
-    let raw_blobs = core::slice::from_raw_parts(blobs, n);
-    let raw_commitments = core::slice::from_raw_parts(commitments_bytes, n);
-    let raw_proofs = core::slice::from_raw_parts(proofs_bytes, n);
+    use kzg::eip_4844::verify_blob_kzg_proof_batch_raw;
 
-    let deserialized_blobs: Result<Vec<Vec<FsFr>>, CKzgRet> = cfg_into_iter!(raw_blobs)
-        .map(|raw_blob| deserialize_blob(raw_blob).map_err(|_| CKzgRet::BadArgs))
-        .collect();
+    let raw_blobs = core::slice::from_raw_parts(blobs, n)
+        .iter()
+        .map(|blob| blob.bytes)
+        .collect::<Vec<_>>();
+    let raw_commitments = core::slice::from_raw_parts(commitments_bytes, n)
+        .iter()
+        .map(|c| c.bytes)
+        .collect::<Vec<_>>();
+    let raw_proofs = core::slice::from_raw_parts(proofs_bytes, n)
+        .iter()
+        .map(|p| p.bytes)
+        .collect::<Vec<_>>();
 
-    let commitments_g1: Result<Vec<FsG1>, CKzgRet> = cfg_into_iter!(raw_commitments)
-        .map(|raw_commitment| FsG1::from_bytes(&raw_commitment.bytes).map_err(|_| CKzgRet::BadArgs))
-        .collect();
+    *ok = false;
 
-    let proofs_g1: Result<Vec<FsG1>, CKzgRet> = cfg_into_iter!(raw_proofs)
-        .map(|raw_proof| FsG1::from_bytes(&raw_proof.bytes).map_err(|_| CKzgRet::BadArgs))
-        .collect();
+    let settings: FsKZGSettings = handle_ckzg_badargs!(s.try_into());
+    let result = handle_ckzg_badargs!(verify_blob_kzg_proof_batch_raw(
+        &raw_blobs,
+        &raw_commitments,
+        &raw_proofs,
+        &settings
+    ));
 
-    if let (Ok(blobs), Ok(commitments), Ok(proofs)) =
-        (deserialized_blobs, commitments_g1, proofs_g1)
-    {
-        let settings: FsKZGSettings = match s.try_into() {
-            Ok(value) => value,
-            Err(_) => return CKzgRet::BadArgs,
-        };
+    *ok = result;
 
-        let result =
-            verify_blob_kzg_proof_batch_rust(blobs.as_slice(), &commitments, &proofs, &settings);
-
-        if let Ok(result) = result {
-            *ok = result;
-            CKzgRet::Ok
-        } else {
-            CKzgRet::BadArgs
-        }
-    } else {
-        *ok = false;
-        CKzgRet::BadArgs
-    }
+    CKzgRet::Ok
 }
 
 /// # Safety
+#[cfg(feature = "c_bindings")]
 #[no_mangle]
 pub unsafe extern "C" fn compute_kzg_proof(
     proof_out: *mut KZGProof,
@@ -385,26 +362,15 @@ pub unsafe extern "C" fn compute_kzg_proof(
     z_bytes: *const Bytes32,
     s: &CKZGSettings,
 ) -> CKzgRet {
-    let deserialized_blob = match deserialize_blob(blob) {
-        Ok(value) => value,
-        Err(err) => return err,
-    };
+    use kzg::eip_4844::compute_kzg_proof_raw;
 
-    let frz = match FsFr::from_bytes(&(*z_bytes).bytes) {
-        Ok(value) => value,
-        Err(_) => return CKzgRet::BadArgs,
-    };
+    let settings: FsKZGSettings = handle_ckzg_badargs!(s.try_into());
 
-    let settings: FsKZGSettings = match s.try_into() {
-        Ok(value) => value,
-        Err(_) => return CKzgRet::BadArgs,
-    };
-
-    let (proof_out_tmp, fry_tmp) = match compute_kzg_proof_rust(&deserialized_blob, &frz, &settings)
-    {
-        Ok(value) => value,
-        Err(_) => return CKzgRet::BadArgs,
-    };
+    let (proof_out_tmp, fry_tmp) = handle_ckzg_badargs!(compute_kzg_proof_raw(
+        (*blob).bytes,
+        (*z_bytes).bytes,
+        &settings
+    ));
 
     (*proof_out).bytes = proof_out_tmp.to_bytes();
     (*y_out).bytes = fry_tmp.to_bytes();

--- a/blst/src/eip_4844.rs
+++ b/blst/src/eip_4844.rs
@@ -1,18 +1,23 @@
 extern crate alloc;
 
-use alloc::boxed::Box;
-use alloc::vec::Vec;
+#[cfg(feature = "c_bindings")]
+use alloc::{boxed::Box, vec::Vec};
+#[cfg(feature = "c_bindings")]
 use core::ptr;
-use kzg::eip_4844::{
-    load_trusted_setup_rust, BYTES_PER_G1, FIELD_ELEMENTS_PER_BLOB, TRUSTED_SETUP_NUM_G1_POINTS,
-    TRUSTED_SETUP_NUM_G2_POINTS,
+use kzg::eip_4844::load_trusted_setup_rust;
+#[cfg(feature = "c_bindings")]
+use kzg::{
+    eip_4844::{
+        BYTES_PER_G1, FIELD_ELEMENTS_PER_BLOB, TRUSTED_SETUP_NUM_G1_POINTS,
+        TRUSTED_SETUP_NUM_G2_POINTS,
+    },
+    eth::{
+        c_bindings::{Blob, Bytes32, Bytes48, CKZGSettings, CKzgRet, KZGCommitment, KZGProof},
+        FIELD_ELEMENTS_PER_CELL, FIELD_ELEMENTS_PER_EXT_BLOB,
+    },
+    Fr, G1,
 };
-use kzg::eth::c_bindings::{
-    Blob, Bytes32, Bytes48, CKZGSettings, CKzgRet, KZGCommitment, KZGProof,
-};
-use kzg::eth::{FIELD_ELEMENTS_PER_CELL, FIELD_ELEMENTS_PER_EXT_BLOB};
-use kzg::{Fr, G1};
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", feature = "c_bindings"))]
 use libc::FILE;
 #[cfg(feature = "std")]
 use std::fs::File;
@@ -22,8 +27,101 @@ use std::io::Read;
 #[cfg(feature = "std")]
 use kzg::eip_4844::load_trusted_setup_string;
 
-use crate::types::kzg_settings::FsKZGSettings;
-use crate::utils::{handle_ckzg_badargs, kzg_settings_to_c, PRECOMPUTATION_TABLES};
+#[cfg(feature = "c_bindings")]
+use crate::{types::kzg_settings::FsKZGSettings, utils::PRECOMPUTATION_TABLES};
+
+#[cfg(feature = "c_bindings")]
+fn kzg_settings_to_c(rust_settings: &FsKZGSettings) -> CKZGSettings {
+    CKZGSettings {
+        roots_of_unity: Box::leak(
+            rust_settings
+                .fs
+                .roots_of_unity
+                .iter()
+                .map(|r| r.0)
+                .collect::<Vec<_>>()
+                .into_boxed_slice(),
+        )
+        .as_mut_ptr(),
+        brp_roots_of_unity: Box::leak(
+            rust_settings
+                .fs
+                .brp_roots_of_unity
+                .iter()
+                .map(|r| r.0)
+                .collect::<Vec<_>>()
+                .into_boxed_slice(),
+        )
+        .as_mut_ptr(),
+        reverse_roots_of_unity: Box::leak(
+            rust_settings
+                .fs
+                .reverse_roots_of_unity
+                .iter()
+                .map(|r| r.0)
+                .collect::<Vec<_>>()
+                .into_boxed_slice(),
+        )
+        .as_mut_ptr(),
+        g1_values_monomial: Box::leak(
+            rust_settings
+                .g1_values_monomial
+                .iter()
+                .map(|r| r.0)
+                .collect::<Vec<_>>()
+                .into_boxed_slice(),
+        )
+        .as_mut_ptr(),
+        g1_values_lagrange_brp: Box::leak(
+            rust_settings
+                .g1_values_lagrange_brp
+                .iter()
+                .map(|r| r.0)
+                .collect::<Vec<_>>()
+                .into_boxed_slice(),
+        )
+        .as_mut_ptr(),
+        g2_values_monomial: Box::leak(
+            rust_settings
+                .g2_values_monomial
+                .iter()
+                .map(|r| r.0)
+                .collect::<Vec<_>>()
+                .into_boxed_slice(),
+        )
+        .as_mut_ptr(),
+        x_ext_fft_columns: Box::leak(
+            rust_settings
+                .x_ext_fft_columns
+                .iter()
+                .map(|r| {
+                    Box::leak(
+                        r.iter()
+                            .map(|it| it.0)
+                            .collect::<Vec<_>>()
+                            .into_boxed_slice(),
+                    )
+                    .as_mut_ptr()
+                })
+                .collect::<Vec<_>>()
+                .into_boxed_slice(),
+        )
+        .as_mut_ptr(),
+        tables: core::ptr::null_mut(),
+        wbits: 0,
+        scratch_size: 0,
+    }
+}
+
+#[cfg(feature = "c_bindings")]
+macro_rules! handle_ckzg_badargs {
+    ($x: expr) => {
+        match $x {
+            Ok(value) => value,
+            Err(_) => return kzg::eth::c_bindings::CKzgRet::BadArgs,
+        }
+    };
+}
 
 #[cfg(feature = "std")]
 pub fn load_trusted_setup_filename_rust(

--- a/blst/src/eip_7594.rs
+++ b/blst/src/eip_7594.rs
@@ -26,4 +26,5 @@ impl EcBackend for BlstBackend {
     type KZGSettings = FsKZGSettings;
 }
 
+#[cfg(feature = "c_bindings")]
 c_bindings_eip7594!(BlstBackend);

--- a/blst/src/eip_7594.rs
+++ b/blst/src/eip_7594.rs
@@ -9,7 +9,6 @@ use crate::types::g1::FsG1Affine;
 use crate::types::g2::FsG2;
 use crate::types::kzg_settings::FsKZGSettings;
 use crate::types::poly::FsPoly;
-use kzg::c_bindings_eip7594;
 
 use crate::types::fr::FsFr;
 
@@ -27,4 +26,4 @@ impl EcBackend for BlstBackend {
 }
 
 #[cfg(feature = "c_bindings")]
-c_bindings_eip7594!(BlstBackend);
+kzg::c_bindings_eip7594!(BlstBackend);

--- a/blst/src/utils.rs
+++ b/blst/src/utils.rs
@@ -1,10 +1,8 @@
 extern crate alloc;
 
-use alloc::boxed::Box;
 use alloc::vec::Vec;
 
 use kzg::eip_4844::{hash_to_bls_field, PrecomputationTableManager};
-use kzg::eth::c_bindings::CKZGSettings;
 use kzg::{Fr, G1Mul, G2Mul};
 
 use crate::consts::{G1_GENERATOR, G2_GENERATOR};
@@ -12,7 +10,6 @@ use crate::types::fp::FsFp;
 use crate::types::fr::FsFr;
 use crate::types::g1::{FsG1, FsG1Affine};
 use crate::types::g2::FsG2;
-use crate::types::kzg_settings::FsKZGSettings;
 
 pub fn generate_trusted_setup(
     n: usize,
@@ -36,102 +33,9 @@ pub fn generate_trusted_setup(
     (s1, s2, s3)
 }
 
-macro_rules! handle_ckzg_badargs {
-    ($x: expr) => {
-        match $x {
-            Ok(value) => value,
-            Err(_) => return kzg::eth::c_bindings::CKzgRet::BadArgs,
-        }
-    };
-}
-
-pub(crate) use handle_ckzg_badargs;
-
 pub(crate) static mut PRECOMPUTATION_TABLES: PrecomputationTableManager<
     FsFr,
     FsG1,
     FsFp,
     FsG1Affine,
 > = PrecomputationTableManager::new();
-
-pub(crate) fn kzg_settings_to_c(rust_settings: &FsKZGSettings) -> CKZGSettings {
-    CKZGSettings {
-        roots_of_unity: Box::leak(
-            rust_settings
-                .fs
-                .roots_of_unity
-                .iter()
-                .map(|r| r.0)
-                .collect::<Vec<_>>()
-                .into_boxed_slice(),
-        )
-        .as_mut_ptr(),
-        brp_roots_of_unity: Box::leak(
-            rust_settings
-                .fs
-                .brp_roots_of_unity
-                .iter()
-                .map(|r| r.0)
-                .collect::<Vec<_>>()
-                .into_boxed_slice(),
-        )
-        .as_mut_ptr(),
-        reverse_roots_of_unity: Box::leak(
-            rust_settings
-                .fs
-                .reverse_roots_of_unity
-                .iter()
-                .map(|r| r.0)
-                .collect::<Vec<_>>()
-                .into_boxed_slice(),
-        )
-        .as_mut_ptr(),
-        g1_values_monomial: Box::leak(
-            rust_settings
-                .g1_values_monomial
-                .iter()
-                .map(|r| r.0)
-                .collect::<Vec<_>>()
-                .into_boxed_slice(),
-        )
-        .as_mut_ptr(),
-        g1_values_lagrange_brp: Box::leak(
-            rust_settings
-                .g1_values_lagrange_brp
-                .iter()
-                .map(|r| r.0)
-                .collect::<Vec<_>>()
-                .into_boxed_slice(),
-        )
-        .as_mut_ptr(),
-        g2_values_monomial: Box::leak(
-            rust_settings
-                .g2_values_monomial
-                .iter()
-                .map(|r| r.0)
-                .collect::<Vec<_>>()
-                .into_boxed_slice(),
-        )
-        .as_mut_ptr(),
-        x_ext_fft_columns: Box::leak(
-            rust_settings
-                .x_ext_fft_columns
-                .iter()
-                .map(|r| {
-                    Box::leak(
-                        r.iter()
-                            .map(|it| it.0)
-                            .collect::<Vec<_>>()
-                            .into_boxed_slice(),
-                    )
-                    .as_mut_ptr()
-                })
-                .collect::<Vec<_>>()
-                .into_boxed_slice(),
-        )
-        .as_mut_ptr(),
-        tables: core::ptr::null_mut(),
-        wbits: 0,
-        scratch_size: 0,
-    }
-}

--- a/blst/src/utils.rs
+++ b/blst/src/utils.rs
@@ -3,8 +3,8 @@ extern crate alloc;
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 
-use kzg::eip_4844::{hash_to_bls_field, PrecomputationTableManager, BYTES_PER_FIELD_ELEMENT};
-use kzg::eth::c_bindings::{Blob, CKZGSettings, CKzgRet};
+use kzg::eip_4844::{hash_to_bls_field, PrecomputationTableManager};
+use kzg::eth::c_bindings::CKZGSettings;
 use kzg::{Fr, G1Mul, G2Mul};
 
 use crate::consts::{G1_GENERATOR, G2_GENERATOR};
@@ -34,22 +34,6 @@ pub fn generate_trusted_setup(
     }
 
     (s1, s2, s3)
-}
-
-pub(crate) unsafe fn deserialize_blob(blob: *const Blob) -> Result<Vec<FsFr>, CKzgRet> {
-    (*blob)
-        .bytes
-        .chunks(BYTES_PER_FIELD_ELEMENT)
-        .map(|chunk| {
-            let mut bytes = [0u8; BYTES_PER_FIELD_ELEMENT];
-            bytes.copy_from_slice(chunk);
-            if let Ok(result) = FsFr::from_bytes(&bytes) {
-                Ok(result)
-            } else {
-                Err(CKzgRet::BadArgs)
-            }
-        })
-        .collect::<Result<Vec<FsFr>, CKzgRet>>()
 }
 
 macro_rules! handle_ckzg_badargs {

--- a/blst/tests/c_bindings.rs
+++ b/blst/tests/c_bindings.rs
@@ -1,4 +1,4 @@
-#[cfg(test)]
+#[cfg(all(test, feature = "c_bindings"))]
 mod tests {
     use kzg_bench::tests::c_bindings::{
         blob_to_kzg_commitment_invalid_blob_test,

--- a/constantine/Cargo.toml
+++ b/constantine/Cargo.toml
@@ -26,7 +26,6 @@ default = [
     "std",
     "rand",
     "bgmw",
-    "c_bindings"
 ]
 std = [
     "hex/std",

--- a/constantine/Cargo.toml
+++ b/constantine/Cargo.toml
@@ -25,7 +25,8 @@ rand = "0.8.5"
 default = [
     "std",
     "rand",
-    "bgmw"
+    "bgmw",
+    "c_bindings"
 ]
 std = [
     "hex/std",
@@ -48,6 +49,7 @@ bgmw = [
 arkmsm = [
     "kzg/arkmsm"
 ]
+c_bindings = []
 
 [[bench]]
 name = "das"

--- a/constantine/src/eip_7594.rs
+++ b/constantine/src/eip_7594.rs
@@ -2,8 +2,6 @@ extern crate alloc;
 
 use kzg::EcBackend;
 
-use kzg::c_bindings_eip7594;
-
 use crate::types::fft_settings::CtFFTSettings;
 use crate::types::fp::CtFp;
 use crate::types::fr::CtFr;
@@ -26,4 +24,5 @@ impl EcBackend for CtBackend {
     type KZGSettings = CtKZGSettings;
 }
 
-c_bindings_eip7594!(CtBackend);
+#[cfg(feature = "c_bindings")]
+kzg::c_bindings_eip7594!(CtBackend);

--- a/constantine/src/utils.rs
+++ b/constantine/src/utils.rs
@@ -12,7 +12,6 @@ use crate::types::fp::CtFp;
 use crate::types::fr::CtFr;
 use crate::types::g1::{CtG1, CtG1Affine};
 use crate::types::g2::CtG2;
-use crate::types::kzg_settings::CtKZGSettings;
 
 pub fn generate_trusted_setup(
     n: usize,
@@ -98,85 +97,3 @@ pub(crate) static mut PRECOMPUTATION_TABLES: PrecomputationTableManager<
     CtFp,
     CtG1Affine,
 > = PrecomputationTableManager::new();
-
-pub(crate) fn kzg_settings_to_c(rust_settings: &CtKZGSettings) -> CKZGSettings {
-    CKZGSettings {
-        roots_of_unity: Box::leak(
-            rust_settings
-                .fs
-                .roots_of_unity
-                .iter()
-                .map(|r| r.to_blst_fr())
-                .collect::<Vec<_>>()
-                .into_boxed_slice(),
-        )
-        .as_mut_ptr(),
-        brp_roots_of_unity: Box::leak(
-            rust_settings
-                .fs
-                .brp_roots_of_unity
-                .iter()
-                .map(|r| r.to_blst_fr())
-                .collect::<Vec<_>>()
-                .into_boxed_slice(),
-        )
-        .as_mut_ptr(),
-        reverse_roots_of_unity: Box::leak(
-            rust_settings
-                .fs
-                .reverse_roots_of_unity
-                .iter()
-                .map(|r| r.to_blst_fr())
-                .collect::<Vec<_>>()
-                .into_boxed_slice(),
-        )
-        .as_mut_ptr(),
-        g1_values_monomial: Box::leak(
-            rust_settings
-                .g1_values_monomial
-                .iter()
-                .map(|r| r.to_blst_p1())
-                .collect::<Vec<_>>()
-                .into_boxed_slice(),
-        )
-        .as_mut_ptr(),
-        g1_values_lagrange_brp: Box::leak(
-            rust_settings
-                .g1_values_lagrange_brp
-                .iter()
-                .map(|r| r.to_blst_p1())
-                .collect::<Vec<_>>()
-                .into_boxed_slice(),
-        )
-        .as_mut_ptr(),
-        g2_values_monomial: Box::leak(
-            rust_settings
-                .g2_values_monomial
-                .iter()
-                .map(|r| r.to_blst_p2())
-                .collect::<Vec<_>>()
-                .into_boxed_slice(),
-        )
-        .as_mut_ptr(),
-        x_ext_fft_columns: Box::leak(
-            rust_settings
-                .x_ext_fft_columns
-                .iter()
-                .map(|r| {
-                    Box::leak(
-                        r.iter()
-                            .map(|it| it.to_blst_p1())
-                            .collect::<Vec<_>>()
-                            .into_boxed_slice(),
-                    )
-                    .as_mut_ptr()
-                })
-                .collect::<Vec<_>>()
-                .into_boxed_slice(),
-        )
-        .as_mut_ptr(),
-        tables: core::ptr::null_mut(),
-        wbits: 0,
-        scratch_size: 0,
-    }
-}

--- a/constantine/src/utils.rs
+++ b/constantine/src/utils.rs
@@ -2,8 +2,8 @@ extern crate alloc;
 
 use alloc::vec::Vec;
 
-use kzg::eip_4844::{hash_to_bls_field, PrecomputationTableManager, BYTES_PER_FIELD_ELEMENT};
-use kzg::eth::c_bindings::{Blob, CKZGSettings, CKzgRet};
+use kzg::eip_4844::{hash_to_bls_field, PrecomputationTableManager};
+use kzg::eth::c_bindings::CKZGSettings;
 use kzg::{eth, Fr, G1Mul, G2Mul};
 
 use crate::consts::{G1_GENERATOR, G2_GENERATOR};
@@ -46,22 +46,6 @@ pub fn ptr_transmute_mut<T, U>(t: &mut T) -> *mut U {
     assert_eq!(core::mem::size_of::<T>(), core::mem::size_of::<U>());
 
     t as *mut T as *mut U
-}
-
-pub(crate) unsafe fn deserialize_blob(blob: *const Blob) -> Result<Vec<CtFr>, CKzgRet> {
-    (*blob)
-        .bytes
-        .chunks(BYTES_PER_FIELD_ELEMENT)
-        .map(|chunk| {
-            let mut bytes = [0u8; BYTES_PER_FIELD_ELEMENT];
-            bytes.copy_from_slice(chunk);
-            if let Ok(result) = CtFr::from_bytes(&bytes) {
-                Ok(result)
-            } else {
-                Err(CKzgRet::BadArgs)
-            }
-        })
-        .collect::<Result<Vec<CtFr>, CKzgRet>>()
 }
 
 pub(crate) fn fft_settings_to_rust(

--- a/constantine/tests/c_bindings.rs
+++ b/constantine/tests/c_bindings.rs
@@ -1,4 +1,4 @@
-#[cfg(test)]
+#[cfg(all(test, feature = "c_bindings"))]
 mod tests {
     use kzg_bench::tests::c_bindings::{
         blob_to_kzg_commitment_invalid_blob_test,

--- a/kzg/src/eip_4844.rs
+++ b/kzg/src/eip_4844.rs
@@ -282,6 +282,24 @@ pub fn blob_to_kzg_commitment_rust<
     Ok(poly_to_kzg_commitment(&polynomial, settings))
 }
 
+pub fn blob_to_kzg_commitment_raw<
+    TFr: Fr,
+    TG1: G1 + G1Mul<TFr> + G1LinComb<TFr, TG1Fp, TG1Affine> + G1GetFp<TG1Fp>,
+    TG2: G2,
+    TFFTSettings: FFTSettings<TFr>,
+    TPoly: Poly<TFr>,
+    TKZGSettings: KZGSettings<TFr, TG1, TG2, TFFTSettings, TPoly, TG1Fp, TG1Affine>,
+    TG1Fp: G1Fp,
+    TG1Affine: G1Affine<TG1, TG1Fp>,
+>(
+    blob: [u8; BYTES_PER_BLOB],
+    settings: &TKZGSettings,
+) -> Result<TG1, String> {
+    let blob = bytes_to_blob(&blob)?;
+
+    blob_to_kzg_commitment_rust(&blob, settings)
+}
+
 pub fn compute_powers<TFr: Fr>(base: &TFr, num_powers: usize) -> Vec<TFr> {
     let mut powers: Vec<TFr> = vec![TFr::default(); num_powers];
     if num_powers == 0 {
@@ -481,6 +499,25 @@ pub fn compute_kzg_proof_rust<
     Ok((proof, y))
 }
 
+pub fn compute_kzg_proof_raw<
+    TFr: Fr + Copy,
+    TG1: G1 + G1Mul<TFr> + G1GetFp<TG1Fp> + G1LinComb<TFr, TG1Fp, TG1Affine>,
+    TG2: G2,
+    TFFTSettings: FFTSettings<TFr>,
+    TPoly: Poly<TFr>,
+    TKZGSettings: KZGSettings<TFr, TG1, TG2, TFFTSettings, TPoly, TG1Fp, TG1Affine>,
+    TG1Fp: G1Fp,
+    TG1Affine: G1Affine<TG1, TG1Fp>,
+>(
+    blob: [u8; BYTES_PER_BLOB],
+    z: [u8; BYTES_PER_FIELD_ELEMENT],
+    s: &TKZGSettings,
+) -> Result<(TG1, TFr), String> {
+    let blob = bytes_to_blob(&blob)?;
+    let z = TFr::from_bytes(&z)?;
+    compute_kzg_proof_rust(&blob, &z, s)
+}
+
 pub fn compute_blob_kzg_proof_rust<
     TFr: Fr + Copy,
     TG1: G1 + G1Mul<TFr> + G1GetFp<TG1Fp> + G1LinComb<TFr, TG1Fp, TG1Affine>,
@@ -502,6 +539,26 @@ pub fn compute_blob_kzg_proof_rust<
     let evaluation_challenge_fr = compute_challenge(blob, commitment);
     let (proof, _) = compute_kzg_proof_rust(blob, &evaluation_challenge_fr, ts)?;
     Ok(proof)
+}
+
+pub fn compute_blob_kzg_proof_raw<
+    TFr: Fr + Copy,
+    TG1: G1 + G1Mul<TFr> + G1GetFp<TG1Fp> + G1LinComb<TFr, TG1Fp, TG1Affine>,
+    TG2: G2,
+    TFFTSettings: FFTSettings<TFr>,
+    TPoly: Poly<TFr>,
+    TKZGSettings: KZGSettings<TFr, TG1, TG2, TFFTSettings, TPoly, TG1Fp, TG1Affine>,
+    TG1Fp: G1Fp,
+    TG1Affine: G1Affine<TG1, TG1Fp>,
+>(
+    blob: [u8; BYTES_PER_BLOB],
+    commitment: [u8; BYTES_PER_G1],
+    ts: &TKZGSettings,
+) -> Result<TG1, String> {
+    let blob = bytes_to_blob(&blob)?;
+    let commitment = TG1::from_bytes(&commitment)?;
+
+    compute_blob_kzg_proof_rust(&blob, &commitment, ts)
 }
 
 pub fn verify_kzg_proof_rust<
@@ -530,6 +587,30 @@ pub fn verify_kzg_proof_rust<
     s.check_proof_single(commitment, proof, z, y)
 }
 
+pub fn verify_kzg_proof_raw<
+    TFr: Fr,
+    TG1: G1 + G1GetFp<TG1Fp> + G1Mul<TFr>,
+    TG2: G2,
+    TFFTSettings: FFTSettings<TFr>,
+    TPoly: Poly<TFr>,
+    TKZGSettings: KZGSettings<TFr, TG1, TG2, TFFTSettings, TPoly, TG1Fp, TG1Affine>,
+    TG1Fp: G1Fp,
+    TG1Affine: G1Affine<TG1, TG1Fp>,
+>(
+    commitment: [u8; BYTES_PER_G1],
+    z: [u8; BYTES_PER_FIELD_ELEMENT],
+    y: [u8; BYTES_PER_FIELD_ELEMENT],
+    proof: [u8; BYTES_PER_G1],
+    s: &TKZGSettings,
+) -> Result<bool, String> {
+    let commitment = TG1::from_bytes(&commitment)?;
+    let z = TFr::from_bytes(&z)?;
+    let y = TFr::from_bytes(&y)?;
+    let proof = TG1::from_bytes(&proof)?;
+
+    verify_kzg_proof_rust(&commitment, &z, &y, &proof, s)
+}
+
 pub fn verify_blob_kzg_proof_rust<
     TFr: Fr + Copy,
     TG1: G1 + G1GetFp<TG1Fp> + G1Mul<TFr>,
@@ -556,6 +637,28 @@ pub fn verify_blob_kzg_proof_rust<
     let evaluation_challenge_fr = compute_challenge(blob, commitment_g1);
     let y_fr = evaluate_polynomial_in_evaluation_form(&polynomial, &evaluation_challenge_fr, ts)?;
     verify_kzg_proof_rust(commitment_g1, &evaluation_challenge_fr, &y_fr, proof_g1, ts)
+}
+
+pub fn verify_blob_kzg_proof_raw<
+    TFr: Fr + Copy,
+    TG1: G1 + G1GetFp<TG1Fp> + G1Mul<TFr>,
+    TG2: G2,
+    TFFTSettings: FFTSettings<TFr>,
+    TPoly: Poly<TFr>,
+    TKZGSettings: KZGSettings<TFr, TG1, TG2, TFFTSettings, TPoly, TG1Fp, TG1Affine>,
+    TG1Fp: G1Fp,
+    TG1Affine: G1Affine<TG1, TG1Fp>,
+>(
+    blob: [u8; BYTES_PER_BLOB],
+    commitment_g1: [u8; BYTES_PER_G1],
+    proof_g1: [u8; BYTES_PER_G1],
+    ts: &TKZGSettings,
+) -> Result<bool, String> {
+    let blob = bytes_to_blob(&blob)?;
+    let commitment_g1 = TG1::from_bytes(&commitment_g1)?;
+    let proof_g1 = TG1::from_bytes(&proof_g1)?;
+
+    verify_blob_kzg_proof_rust(&blob, &commitment_g1, &proof_g1, ts)
 }
 
 fn compute_challenges_and_evaluate_polynomial<
@@ -696,7 +799,34 @@ pub fn verify_blob_kzg_proof_batch_rust<
     }
 }
 
-#[allow(clippy::useless_conversion)]
+pub fn verify_blob_kzg_proof_batch_raw<
+    TFr: Fr + Copy + Send,
+    TG1: G1 + G1Mul<TFr> + PairingVerify<TG1, TG2> + G1GetFp<TG1Fp> + G1LinComb<TFr, TG1Fp, TG1Affine>,
+    TG2: G2,
+    TFFTSettings: FFTSettings<TFr>,
+    TPoly: Poly<TFr>,
+    TKZGSettings: KZGSettings<TFr, TG1, TG2, TFFTSettings, TPoly, TG1Fp, TG1Affine> + Sync,
+    TG1Fp: G1Fp,
+    TG1Affine: G1Affine<TG1, TG1Fp>,
+>(
+    blobs: &[[u8; BYTES_PER_BLOB]],
+    commitments_g1: &[[u8; BYTES_PER_G1]],
+    proofs_g1: &[[u8; BYTES_PER_G1]],
+    ts: &TKZGSettings,
+) -> Result<bool, String> {
+    let blobs = cfg_into_iter!(blobs)
+        .map(|bytes| bytes_to_blob(bytes))
+        .collect::<Result<Vec<_>, _>>()?;
+    let commitments_g1 = cfg_into_iter!(commitments_g1)
+        .map(|bytes| TG1::from_bytes(bytes))
+        .collect::<Result<Vec<_>, _>>()?;
+    let proofs_g1 = cfg_into_iter!(proofs_g1)
+        .map(|bytes| TG1::from_bytes(bytes))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    verify_blob_kzg_proof_batch_rust(&blobs, &commitments_g1, &proofs_g1, ts)
+}
+
 pub fn bytes_to_blob<TFr: Fr>(bytes: &[u8]) -> Result<Vec<TFr>, String> {
     if bytes.len() != BYTES_PER_BLOB {
         return Err(format!(
@@ -854,7 +984,6 @@ fn is_trusted_setup_in_lagrange_form<TG1: G1 + PairingVerify<TG1, TG2>, TG2: G2>
     !is_monotomial_form
 }
 
-#[allow(clippy::useless_conversion)]
 pub fn load_trusted_setup_rust<
     TFr: Fr,
     TG1: G1 + G1Mul<TFr> + G1GetFp<TG1Fp> + PairingVerify<TG1, TG2>,

--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,12 @@ Support for multiple backend ECC libraries is implemented via [Traits](https://g
 
 # Drop-in replacement for c-kzg-4844
 
-We aim to expose [an identical C interface](https://github.com/sifraitech/rust-kzg/blob/b4de1923a6218ea37021d0f9e3bd375dbf529d34/blst-from-scratch/src/eip_4844.rs#L604:L835) compared to [c-kzg-4844](https://github.com/ethereum/c-kzg-4844) so that `rust-kzg` could work as a drop-in replacement for c-kzg-4844. If you already use [c-kzg-4844 bindings](https://github.com/ethereum/c-kzg-4844/tree/main/bindings) you can try faster paralellized `rust-kzg` without any changes to your code-base by simply replacing the binary. Instructions for C#, Java, Nodejs, Python, Rust bindings are available [here](https://github.com/sifraitech/rust-kzg/blob/main/blst/run-c-kzg-4844-tests.sh).
+We aim to expose [an identical C interface](https://github.com/grandinetech/rust-kzg/blob/ca976958e270cd24248a5ab0355b03702f7ae142/blst/src/eip_4844.rs#L53-L412) compared to [c-kzg-4844](https://github.com/ethereum/c-kzg-4844) so that `rust-kzg` could work as a drop-in replacement for c-kzg-4844. If you already use [c-kzg-4844 bindings](https://github.com/ethereum/c-kzg-4844/tree/main/bindings) you can try faster paralellized `rust-kzg` without any changes to your code-base by simply replacing the binary. Instructions for C#, Java, Nodejs, Python, Rust bindings are available [here](https://github.com/sifraitech/rust-kzg/blob/main/blst/run-c-kzg-4844-tests.sh).
+
+By default, C bindings are disabled. To enable them, compile static library with feature flag `c_bindings`:
+```
+cargo rustc -p rust-kzg-blst --release --crate-type=staticlib --features=c_bindings
+```
 
 # Example
 

--- a/run-c-kzg-4844-benches.sh
+++ b/run-c-kzg-4844-benches.sh
@@ -39,10 +39,10 @@ cd $backend
 
 if [[ "$parallel" = true ]]; then
   print_msg "Using parallel version"
-  cargo rustc --release --crate-type=staticlib --features=parallel
+  cargo rustc --release --crate-type=staticlib --features=c_bindings,parallel
 else
   print_msg "Using non-parallel version"
-  cargo rustc --release --crate-type=staticlib
+  cargo rustc --release --crate-type=staticlib --features=c_bindings
 fi
 
 ###################### cloning c-kzg-4844 ######################

--- a/run-c-kzg-4844-fuzz.sh
+++ b/run-c-kzg-4844-fuzz.sh
@@ -42,16 +42,16 @@ if [ "$backend" == "unknown" ]; then
   exit 1
 fi
 
-features=""
+features="c_bindings"
 
 #Check if --arkmsm is specified
 if [ "$use_arkmsm" = true ]; then
-  features+="arkmsm,"
+  features+=",arkmsm"
 fi
 
 # Check if --bgmw is specified
 if [ "$use_bgmw" = true ]; then
-  features+="bgmw"
+  features+=",bgmw"
 fi
 
 # Trim the trailing comma, if any
@@ -63,7 +63,7 @@ cd $backend
 
 if [[ "$parallel" = true ]]; then
   print_msg "Using parallel version"
-  cargo rustc --release --crate-type=staticlib --features="$features"
+  cargo rustc --release --crate-type=staticlib --features="$features,parallel"
 else
   print_msg "Using non-parallel version"
   cargo rustc --release --crate-type=staticlib --features="$features"

--- a/run-c-kzg-4844-tests.sh
+++ b/run-c-kzg-4844-tests.sh
@@ -37,10 +37,10 @@ cd $backend
 
 if [[ "$parallel" = true ]]; then
   print_msg "Using parallel version"
-  cargo rustc --release --crate-type=staticlib --features=parallel
+  cargo rustc --release --crate-type=staticlib --features=c_bindings,parallel
 else
   print_msg "Using non-parallel version"
-  cargo rustc --release --crate-type=staticlib
+  cargo rustc --release --crate-type=staticlib --features=c_bindings
 fi
 
 ###################### cloning c-kzg-4844 ######################

--- a/zkcrypto/Cargo.toml
+++ b/zkcrypto/Cargo.toml
@@ -23,7 +23,8 @@ rand = { version = "0.8.5" }
 [features]
 default = [
     "std",
-    "rand"
+    "rand",
+    "c_bindings"
 ]
 std = [
     "kzg/std",
@@ -36,6 +37,7 @@ rand = [
     "dep:rand",
     "kzg/rand",
 ]
+c_bindings = []
 
 [[bench]]
 name = "fft"

--- a/zkcrypto/Cargo.toml
+++ b/zkcrypto/Cargo.toml
@@ -24,7 +24,6 @@ rand = { version = "0.8.5" }
 default = [
     "std",
     "rand",
-    "c_bindings"
 ]
 std = [
     "kzg/std",

--- a/zkcrypto/src/eip_4844.rs
+++ b/zkcrypto/src/eip_4844.rs
@@ -1,20 +1,15 @@
 extern crate alloc;
 
 use crate::kzg_proofs::KZGSettings;
-use crate::kzg_types::{ZFr, ZG1};
-use crate::utils::{
-    deserialize_blob, handle_ckzg_badargs, kzg_settings_to_c, PRECOMPUTATION_TABLES,
-};
+use crate::utils::{handle_ckzg_badargs, kzg_settings_to_c, PRECOMPUTATION_TABLES};
 use kzg::eip_4844::{
-    blob_to_kzg_commitment_rust, compute_blob_kzg_proof_rust, compute_kzg_proof_rust,
-    load_trusted_setup_rust, verify_blob_kzg_proof_batch_rust, verify_blob_kzg_proof_rust,
-    verify_kzg_proof_rust, BYTES_PER_G1, FIELD_ELEMENTS_PER_BLOB, TRUSTED_SETUP_NUM_G1_POINTS,
+    load_trusted_setup_rust, BYTES_PER_G1, FIELD_ELEMENTS_PER_BLOB, TRUSTED_SETUP_NUM_G1_POINTS,
     TRUSTED_SETUP_NUM_G2_POINTS,
 };
 use kzg::eth::c_bindings::{
     Blob, Bytes32, Bytes48, CKZGSettings, CKzgRet, KZGCommitment, KZGProof,
 };
-use kzg::{cfg_into_iter, eth, Fr, G1};
+use kzg::{eth, Fr, G1};
 use std::ptr::{self};
 
 #[cfg(feature = "std")]
@@ -24,12 +19,11 @@ use std::fs::File;
 #[cfg(feature = "std")]
 use std::io::Read;
 
-#[cfg(feature = "parallel")]
-use rayon::prelude::*;
-
 #[cfg(feature = "std")]
 use kzg::eip_4844::load_trusted_setup_string;
+
 /// # Safety
+#[cfg(feature = "c_bindings")]
 #[no_mangle]
 pub unsafe extern "C" fn load_trusted_setup(
     out: *mut CKZGSettings,
@@ -76,7 +70,7 @@ pub unsafe extern "C" fn load_trusted_setup(
 }
 
 /// # Safety
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", feature = "c_bindings"))]
 #[no_mangle]
 pub unsafe extern "C" fn load_trusted_setup_file(
     out: *mut CKZGSettings,
@@ -139,26 +133,29 @@ pub fn load_trusted_setup_filename_rust(
 }
 
 /// # Safety
+#[cfg(feature = "c_bindings")]
 #[no_mangle]
 pub unsafe extern "C" fn blob_to_kzg_commitment(
     out: *mut KZGCommitment,
     blob: *const Blob,
     s: &CKZGSettings,
 ) -> CKzgRet {
+    use kzg::eip_4844::blob_to_kzg_commitment_raw;
+
     if TRUSTED_SETUP_NUM_G1_POINTS == 0 {
         // FIXME: load_trusted_setup should set this value, but if not, it fails
         TRUSTED_SETUP_NUM_G1_POINTS = FIELD_ELEMENTS_PER_BLOB
     };
 
-    let deserialized_blob = handle_ckzg_badargs!(deserialize_blob(blob));
     let settings: KZGSettings = handle_ckzg_badargs!(s.try_into());
-    let tmp = handle_ckzg_badargs!(blob_to_kzg_commitment_rust(&deserialized_blob, &settings));
+    let tmp = handle_ckzg_badargs!(blob_to_kzg_commitment_raw((*blob).bytes, &settings));
 
     (*out).bytes = tmp.to_bytes();
     CKzgRet::Ok
 }
 
 /// # Safety
+#[cfg(feature = "c_bindings")]
 #[no_mangle]
 pub unsafe extern "C" fn free_trusted_setup(s: *mut CKZGSettings) {
     if s.is_null() {
@@ -245,6 +242,7 @@ pub unsafe extern "C" fn free_trusted_setup(s: *mut CKZGSettings) {
 }
 
 /// # Safety
+#[cfg(feature = "c_bindings")]
 #[no_mangle]
 pub unsafe extern "C" fn verify_kzg_proof(
     ok: *mut bool,
@@ -254,18 +252,15 @@ pub unsafe extern "C" fn verify_kzg_proof(
     proof_bytes: *const Bytes48,
     s: &CKZGSettings,
 ) -> CKzgRet {
-    let frz = handle_ckzg_badargs!(ZFr::from_bytes(&(*z_bytes).bytes));
-    let fry = handle_ckzg_badargs!(ZFr::from_bytes(&(*y_bytes).bytes));
-    let g1commitment = handle_ckzg_badargs!(ZG1::from_bytes(&(*commitment_bytes).bytes));
-    let g1proof = handle_ckzg_badargs!(ZG1::from_bytes(&(*proof_bytes).bytes));
+    use kzg::eip_4844::verify_kzg_proof_raw;
 
     let settings: KZGSettings = handle_ckzg_badargs!(s.try_into());
 
-    let result = handle_ckzg_badargs!(verify_kzg_proof_rust(
-        &g1commitment,
-        &frz,
-        &fry,
-        &g1proof,
+    let result = handle_ckzg_badargs!(verify_kzg_proof_raw(
+        (*commitment_bytes).bytes,
+        (*z_bytes).bytes,
+        (*y_bytes).bytes,
+        (*proof_bytes).bytes,
         &settings
     ));
 
@@ -274,6 +269,7 @@ pub unsafe extern "C" fn verify_kzg_proof(
 }
 
 /// # Safety
+#[cfg(feature = "c_bindings")]
 #[no_mangle]
 pub unsafe extern "C" fn verify_blob_kzg_proof(
     ok: *mut bool,
@@ -282,15 +278,14 @@ pub unsafe extern "C" fn verify_blob_kzg_proof(
     proof_bytes: *const Bytes48,
     s: &CKZGSettings,
 ) -> CKzgRet {
-    let deserialized_blob = handle_ckzg_badargs!(deserialize_blob(blob));
-    let commitment_g1 = handle_ckzg_badargs!(ZG1::from_bytes(&(*commitment_bytes).bytes));
-    let proof_g1 = handle_ckzg_badargs!(ZG1::from_bytes(&(*proof_bytes).bytes));
+    use kzg::eip_4844::verify_blob_kzg_proof_raw;
+
     let settings: KZGSettings = handle_ckzg_badargs!(s.try_into());
 
-    let result = handle_ckzg_badargs!(verify_blob_kzg_proof_rust(
-        &deserialized_blob,
-        &commitment_g1,
-        &proof_g1,
+    let result = handle_ckzg_badargs!(verify_blob_kzg_proof_raw(
+        (*blob).bytes,
+        (*commitment_bytes).bytes,
+        (*proof_bytes).bytes,
         &settings,
     ));
 
@@ -299,6 +294,7 @@ pub unsafe extern "C" fn verify_blob_kzg_proof(
 }
 
 /// # Safety
+#[cfg(feature = "c_bindings")]
 #[no_mangle]
 pub unsafe extern "C" fn verify_blob_kzg_proof_batch(
     ok: *mut bool,
@@ -308,43 +304,38 @@ pub unsafe extern "C" fn verify_blob_kzg_proof_batch(
     n: usize,
     s: &CKZGSettings,
 ) -> CKzgRet {
-    let raw_blobs = core::slice::from_raw_parts(blobs, n);
-    let raw_commitments = core::slice::from_raw_parts(commitments_bytes, n);
-    let raw_proofs = core::slice::from_raw_parts(proofs_bytes, n);
+    use kzg::eip_4844::verify_blob_kzg_proof_batch_raw;
 
-    let deserialized_blobs: Result<Vec<Vec<ZFr>>, CKzgRet> = cfg_into_iter!(raw_blobs)
-        .map(|raw_blob| deserialize_blob(raw_blob).map_err(|_| CKzgRet::BadArgs))
-        .collect();
+    let blobs = core::slice::from_raw_parts(blobs, n)
+        .iter()
+        .map(|v| v.bytes)
+        .collect::<Vec<_>>();
+    let commitments = core::slice::from_raw_parts(commitments_bytes, n)
+        .iter()
+        .map(|v| v.bytes)
+        .collect::<Vec<_>>();
+    let proofs = core::slice::from_raw_parts(proofs_bytes, n)
+        .iter()
+        .map(|v| v.bytes)
+        .collect::<Vec<_>>();
 
-    let commitments_g1: Result<Vec<ZG1>, CKzgRet> = cfg_into_iter!(raw_commitments)
-        .map(|raw_commitment| ZG1::from_bytes(&raw_commitment.bytes).map_err(|_| CKzgRet::BadArgs))
-        .collect();
+    *ok = false;
 
-    let proofs_g1: Result<Vec<ZG1>, CKzgRet> = cfg_into_iter!(raw_proofs)
-        .map(|raw_proof| ZG1::from_bytes(&raw_proof.bytes).map_err(|_| CKzgRet::BadArgs))
-        .collect();
+    let settings: KZGSettings = handle_ckzg_badargs!(s.try_into());
 
-    if let (Ok(blobs), Ok(commitments), Ok(proofs)) =
-        (deserialized_blobs, commitments_g1, proofs_g1)
-    {
-        let settings: KZGSettings = handle_ckzg_badargs!(s.try_into());
+    let result = handle_ckzg_badargs!(verify_blob_kzg_proof_batch_raw(
+        &blobs,
+        &commitments,
+        &proofs,
+        &settings
+    ));
 
-        let result =
-            verify_blob_kzg_proof_batch_rust(blobs.as_slice(), &commitments, &proofs, &settings);
-
-        if let Ok(result) = result {
-            *ok = result;
-            CKzgRet::Ok
-        } else {
-            CKzgRet::BadArgs
-        }
-    } else {
-        *ok = false;
-        CKzgRet::BadArgs
-    }
+    *ok = result;
+    CKzgRet::Ok
 }
 
 /// # Safety
+#[cfg(feature = "c_bindings")]
 #[no_mangle]
 pub unsafe extern "C" fn compute_blob_kzg_proof(
     out: *mut KZGProof,
@@ -352,16 +343,12 @@ pub unsafe extern "C" fn compute_blob_kzg_proof(
     commitment_bytes: *const Bytes48,
     s: &CKZGSettings,
 ) -> CKzgRet {
-    let deserialized_blob = match deserialize_blob(blob) {
-        Ok(value) => value,
-        Err(err) => return err,
-    };
+    use kzg::eip_4844::compute_blob_kzg_proof_raw;
 
-    let commitment_g1 = handle_ckzg_badargs!(ZG1::from_bytes(&(*commitment_bytes).bytes));
     let settings: KZGSettings = handle_ckzg_badargs!(s.try_into());
-    let proof = handle_ckzg_badargs!(compute_blob_kzg_proof_rust(
-        &deserialized_blob,
-        &commitment_g1,
+    let proof = handle_ckzg_badargs!(compute_blob_kzg_proof_raw(
+        (*blob).bytes,
+        (*commitment_bytes).bytes,
         &settings
     ));
 
@@ -370,6 +357,7 @@ pub unsafe extern "C" fn compute_blob_kzg_proof(
 }
 
 /// # Safety
+#[cfg(feature = "c_bindings")]
 #[no_mangle]
 pub unsafe extern "C" fn compute_kzg_proof(
     proof_out: *mut KZGProof,
@@ -378,17 +366,15 @@ pub unsafe extern "C" fn compute_kzg_proof(
     z_bytes: *const Bytes32,
     s: &CKZGSettings,
 ) -> CKzgRet {
-    let deserialized_blob = match deserialize_blob(blob) {
-        Ok(value) => value,
-        Err(err) => return err,
-    };
-
-    let frz = handle_ckzg_badargs!(ZFr::from_bytes(&(*z_bytes).bytes));
+    use kzg::eip_4844::compute_kzg_proof_raw;
 
     let settings: KZGSettings = handle_ckzg_badargs!(s.try_into());
 
-    let (proof_out_tmp, fry_tmp) =
-        handle_ckzg_badargs!(compute_kzg_proof_rust(&deserialized_blob, &frz, &settings));
+    let (proof_out_tmp, fry_tmp) = handle_ckzg_badargs!(compute_kzg_proof_raw(
+        (*blob).bytes,
+        (*z_bytes).bytes,
+        &settings
+    ));
 
     (*proof_out).bytes = proof_out_tmp.to_bytes();
     (*y_out).bytes = fry_tmp.to_bytes();

--- a/zkcrypto/src/eip_7594.rs
+++ b/zkcrypto/src/eip_7594.rs
@@ -2,8 +2,6 @@ extern crate alloc;
 
 use kzg::EcBackend;
 
-use kzg::c_bindings_eip7594;
-
 use crate::kzg_proofs::FFTSettings;
 use crate::kzg_proofs::KZGSettings;
 use crate::kzg_types::ZFp;
@@ -26,4 +24,5 @@ impl EcBackend for ZBackend {
     type KZGSettings = KZGSettings;
 }
 
-c_bindings_eip7594!(ZBackend);
+#[cfg(feature = "c_bindings")]
+kzg::c_bindings_eip7594!(ZBackend);

--- a/zkcrypto/src/utils.rs
+++ b/zkcrypto/src/utils.rs
@@ -8,11 +8,7 @@ use bls12_381::{G1Projective, G2Projective, Scalar};
 use blst::{blst_fp, blst_fp2, blst_fr, blst_p1, blst_p2};
 use kzg::{
     eip_4844::PrecomputationTableManager,
-    eth::{
-        self,
-        c_bindings::{Blob, CKZGSettings, CKzgRet},
-    },
-    Fr,
+    eth::{self, c_bindings::CKZGSettings},
 };
 
 #[derive(Debug, PartialEq, Eq)]
@@ -201,22 +197,6 @@ pub(crate) fn kzg_settings_to_c(rust_settings: &KZGSettings) -> CKZGSettings {
         wbits: 0,
         scratch_size: 0,
     }
-}
-
-pub(crate) unsafe fn deserialize_blob(blob: *const Blob) -> Result<Vec<ZFr>, CKzgRet> {
-    (*blob)
-        .bytes
-        .chunks(eth::BYTES_PER_FIELD_ELEMENT)
-        .map(|chunk| {
-            let mut bytes = [0u8; eth::BYTES_PER_FIELD_ELEMENT];
-            bytes.copy_from_slice(chunk);
-            if let Ok(result) = ZFr::from_bytes(&bytes) {
-                Ok(result)
-            } else {
-                Err(CKzgRet::BadArgs)
-            }
-        })
-        .collect::<Result<Vec<ZFr>, CKzgRet>>()
 }
 
 pub(crate) static mut PRECOMPUTATION_TABLES: PrecomputationTableManager<ZFr, ZG1, ZFp, ZG1Affine> =


### PR DESCRIPTION
In this PR:
* Added "c_bindings" feature in backend crates, allowing to optionally disable C bindings
* Added `_raw` functions, that accept raw bytes

Related: https://github.com/grandinetech/grandine/issues/73