### PR TITLE
Remove blst dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1053,7 +1053,6 @@ dependencies = [
 name = "kzg"
 version = "0.1.0"
 dependencies = [
- "blst",
  "num_cpus",
  "rayon",
  "sha2 0.10.8",
@@ -1440,7 +1439,6 @@ dependencies = [
  "ark-poly 0.4.2",
  "ark-serialize 0.4.2",
  "ark-std 0.4.0",
- "blst",
  "criterion 0.5.1",
  "hex",
  "kzg",
@@ -1589,7 +1587,6 @@ name = "rust-kzg-zkcrypto"
 version = "0.1.0"
 dependencies = [
  "bls12_381",
- "blst",
  "byteorder",
  "criterion 0.5.1",
  "ff",

--- a/arkworks/Cargo.toml
+++ b/arkworks/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-blst = "0.3.11"
 kzg = { path = "../kzg", default-features = false }
 ark-std = { version = "^0.4.0", default-features = false }
 ark-ff = { version = "^0.4.2", default-features = false, features = [ "asm" ] }

--- a/arkworks/src/consts.rs
+++ b/arkworks/src/consts.rs
@@ -1,6 +1,6 @@
+use kzg::eth::c_bindings::{blst_fp, blst_fp2, blst_p1, blst_p2};
+
 use crate::kzg_types::{ArkG1, ArkG2};
-use crate::P2;
-use blst::{blst_fp, blst_fp2, blst_p1};
 
 /** The G1 identity/infinity */
 #[rustfmt::skip]
@@ -117,7 +117,7 @@ pub const G1_NEGATIVE_GENERATOR: ArkG1 = ArkG1::from_blst_p1(blst_p1 {
     },
 });
 
-pub const G2_GENERATOR: ArkG2 = ArkG2::from_blst_p2(P2 {
+pub const G2_GENERATOR: ArkG2 = ArkG2::from_blst_p2(blst_p2 {
     x: blst_fp2 {
         fp: [
             blst_fp {
@@ -192,7 +192,7 @@ pub const G2_GENERATOR: ArkG2 = ArkG2::from_blst_p2(P2 {
     },
 });
 
-pub const G2_NEGATIVE_GENERATOR: ArkG2 = ArkG2::from_blst_p2(P2 {
+pub const G2_NEGATIVE_GENERATOR: ArkG2 = ArkG2::from_blst_p2(blst_p2 {
     x: blst_fp2 {
         fp: [
             blst_fp {

--- a/arkworks/src/kzg_types.rs
+++ b/arkworks/src/kzg_types.rs
@@ -23,11 +23,10 @@ use ark_std::{One, Zero};
 
 #[cfg(feature = "rand")]
 use ark_std::UniformRand;
-use kzg::eth::c_bindings::CKZGSettings;
+use kzg::eth::c_bindings::{blst_fp, blst_fr, blst_p1, blst_p2, CKZGSettings};
 
 use crate::fft_g1::fft_g1_fast;
 
-use blst::{blst_fp, blst_fr, blst_p1};
 use kzg::common_utils::reverse_bit_order;
 use kzg::msm::precompute::{precompute, PrecomputationTable};
 use kzg::{
@@ -422,11 +421,11 @@ impl PairingVerify<ArkG1, ArkG2> for ArkG1 {
 pub struct ArkG2(pub Projective<g2::Config>);
 
 impl ArkG2 {
-    pub const fn from_blst_p2(p2: blst::blst_p2) -> Self {
+    pub const fn from_blst_p2(p2: blst_p2) -> Self {
         Self(blst_p2_into_pc_g2projective(&p2))
     }
 
-    pub const fn to_blst_p2(&self) -> blst::blst_p2 {
+    pub const fn to_blst_p2(&self) -> blst_p2 {
         pc_g2projective_into_blst_p2(self.0)
     }
 }

--- a/arkworks/src/lib.rs
+++ b/arkworks/src/lib.rs
@@ -1,15 +1,3 @@
-pub type Pairing = blst::Pairing;
-pub type Fp = blst::blst_fp;
-pub type Fp12 = blst::blst_fp12;
-pub type Fp6 = blst::blst_fp6;
-pub type Fr = blst::blst_fr;
-pub type P1 = blst::blst_p1;
-pub type P1Affine = blst::blst_p1_affine;
-pub type P2 = blst::blst_p2;
-pub type P2Affine = blst::blst_p2_affine;
-pub type Scalar = blst::blst_scalar;
-pub type Uniq = blst::blst_uniq;
-
 pub mod consts;
 pub mod das;
 pub mod eip_4844;

--- a/arkworks/src/utils.rs
+++ b/arkworks/src/utils.rs
@@ -1,16 +1,13 @@
-use super::{Fp, P1};
 use crate::kzg_proofs::FFTSettings;
 use crate::kzg_types::{ArkFp, ArkFr, ArkG1, ArkG1Affine};
-use crate::P2;
 use ark_bls12_381::{g1, g2, Fq, Fq2, Fr as Bls12Fr};
 use ark_ec::models::short_weierstrass::Projective;
 use ark_ff::Fp2;
 use ark_poly::univariate::DensePolynomial as DensePoly;
 use ark_poly::DenseUVPolynomial;
-use blst::{blst_fp, blst_fp2, blst_fr, blst_p1, blst_p2};
 
 use kzg::eip_4844::PrecomputationTableManager;
-use kzg::eth::c_bindings::CKZGSettings;
+use kzg::eth::c_bindings::{blst_fp, blst_fp2, blst_fr, blst_p1, blst_p2, CKZGSettings};
 
 use kzg::eth;
 
@@ -39,8 +36,8 @@ pub fn blst_poly_into_pc_poly(pd: &[ArkFr]) -> DensePoly<Bls12Fr> {
     DensePoly::from_coefficients_vec(poly)
 }
 
-pub const fn pc_fq_into_blst_fp(fq: Fq) -> Fp {
-    Fp { l: fq.0 .0 }
+pub const fn pc_fq_into_blst_fp(fq: Fq) -> blst_fp {
+    blst_fp { l: fq.0 .0 }
 }
 
 pub const fn blst_fr_into_pc_fr(fr: blst_fr) -> Bls12Fr {
@@ -51,10 +48,10 @@ pub const fn blst_fr_into_pc_fr(fr: blst_fr) -> Bls12Fr {
 }
 
 pub const fn pc_fr_into_blst_fr(fr: Bls12Fr) -> blst_fr {
-    blst::blst_fr { l: fr.0 .0 }
+    blst_fr { l: fr.0 .0 }
 }
 
-pub const fn blst_fp_into_pc_fq(fp: &Fp) -> Fq {
+pub const fn blst_fp_into_pc_fq(fp: &blst_fp) -> Fq {
     Fq {
         0: ark_ff::BigInt(fp.l),
         1: core::marker::PhantomData,
@@ -68,7 +65,7 @@ pub const fn blst_fp2_into_pc_fq2(fp: &blst_fp2) -> Fq2 {
     }
 }
 
-pub const fn blst_p1_into_pc_g1projective(p1: &P1) -> Projective<g1::Config> {
+pub const fn blst_p1_into_pc_g1projective(p1: &blst_p1) -> Projective<g1::Config> {
     Projective {
         x: blst_fp_into_pc_fq(&p1.x),
         y: blst_fp_into_pc_fq(&p1.y),
@@ -84,7 +81,7 @@ pub const fn pc_g1projective_into_blst_p1(p1: Projective<g1::Config>) -> blst_p1
     }
 }
 
-pub const fn blst_p2_into_pc_g2projective(p2: &P2) -> Projective<g2::Config> {
+pub const fn blst_p2_into_pc_g2projective(p2: &blst_p2) -> Projective<g2::Config> {
     Projective {
         x: blst_fp2_into_pc_fq2(&p2.x),
         y: blst_fp2_into_pc_fq2(&p2.y),
@@ -94,23 +91,14 @@ pub const fn blst_p2_into_pc_g2projective(p2: &P2) -> Projective<g2::Config> {
 
 pub const fn pc_g2projective_into_blst_p2(p2: Projective<g2::Config>) -> blst_p2 {
     blst_p2 {
-        x: blst::blst_fp2 {
-            fp: [
-                blst::blst_fp { l: p2.x.c0.0 .0 },
-                blst::blst_fp { l: p2.x.c1.0 .0 },
-            ],
+        x: blst_fp2 {
+            fp: [blst_fp { l: p2.x.c0.0 .0 }, blst_fp { l: p2.x.c1.0 .0 }],
         },
-        y: blst::blst_fp2 {
-            fp: [
-                blst::blst_fp { l: p2.y.c0.0 .0 },
-                blst::blst_fp { l: p2.y.c1.0 .0 },
-            ],
+        y: blst_fp2 {
+            fp: [blst_fp { l: p2.y.c0.0 .0 }, blst_fp { l: p2.y.c1.0 .0 }],
         },
-        z: blst::blst_fp2 {
-            fp: [
-                blst::blst_fp { l: p2.z.c0.0 .0 },
-                blst::blst_fp { l: p2.z.c1.0 .0 },
-            ],
+        z: blst_fp2 {
+            fp: [blst_fp { l: p2.z.c0.0 .0 }, blst_fp { l: p2.z.c1.0 .0 }],
         },
     }
 }

--- a/arkworks3/src/lib.rs
+++ b/arkworks3/src/lib.rs
@@ -1,15 +1,3 @@
-pub type Pairing = blst::Pairing;
-pub type Fp = blst::blst_fp;
-pub type Fp12 = blst::blst_fp12;
-pub type Fp6 = blst::blst_fp6;
-pub type Fr = blst::blst_fr;
-pub type P1 = blst::blst_p1;
-pub type P1Affine = blst::blst_p1_affine;
-pub type P2 = blst::blst_p2;
-pub type P2Affine = blst::blst_p2_affine;
-pub type Scalar = blst::blst_scalar;
-pub type Uniq = blst::blst_uniq;
-
 pub mod consts;
 pub mod das;
 pub mod eip_4844;

--- a/arkworks3/src/utils.rs
+++ b/arkworks3/src/utils.rs
@@ -2,20 +2,20 @@ extern crate alloc;
 
 use kzg::{
     eip_4844::PrecomputationTableManager,
-    eth::{self, c_bindings::CKZGSettings},
+    eth::{
+        self,
+        c_bindings::{blst_fp, blst_fp2, blst_fr, blst_p1, blst_p2, CKZGSettings},
+    },
 };
 
 use crate::kzg_proofs::FFTSettings as LFFTSettings;
 use crate::kzg_types::{ArkFp, ArkFr, ArkG1, ArkG1Affine};
 
-use super::{Fp, P1};
-use crate::P2;
 use ark_bls12_381::{g1, g2, Fq, Fq2};
 use ark_ec::models::short_weierstrass_jacobian::GroupProjective;
 use ark_ff::{BigInteger256, BigInteger384, Fp2};
 use ark_poly::univariate::DensePolynomial as DensePoly;
 use ark_poly::UVPolynomial;
-use blst::{blst_fp, blst_fp2, blst_fr, blst_p1, blst_p2};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Error;
@@ -93,8 +93,8 @@ pub fn blst_poly_into_pc_poly(pd: &[ArkFr]) -> DensePoly<ark_bls12_381::Fr> {
     DensePoly::from_coefficients_vec(poly)
 }
 
-pub const fn pc_fq_into_blst_fp(fq: Fq) -> Fp {
-    Fp { l: fq.0 .0 }
+pub const fn pc_fq_into_blst_fp(fq: Fq) -> blst_fp {
+    blst_fp { l: fq.0 .0 }
 }
 
 pub const fn blst_fr_into_pc_fr(fr: blst_fr) -> ark_bls12_381::Fr {
@@ -104,10 +104,10 @@ pub const fn blst_fr_into_pc_fr(fr: blst_fr) -> ark_bls12_381::Fr {
 }
 
 pub const fn pc_fr_into_blst_fr(fr: ark_bls12_381::Fr) -> blst_fr {
-    blst::blst_fr { l: fr.0 .0 }
+    blst_fr { l: fr.0 .0 }
 }
 
-pub const fn blst_fp_into_pc_fq(fp: &Fp) -> Fq {
+pub const fn blst_fp_into_pc_fq(fp: &blst_fp) -> Fq {
     let big_int = BigInteger384::new(fp.l);
     Fq::new(big_int)
 }
@@ -116,7 +116,7 @@ pub fn blst_fp2_into_pc_fq2(fp: &blst_fp2) -> Fq2 {
     Fp2::new(blst_fp_into_pc_fq(&fp.fp[0]), blst_fp_into_pc_fq(&fp.fp[1]))
 }
 
-pub fn blst_p1_into_pc_g1projective(p1: &P1) -> GroupProjective<g1::Parameters> {
+pub fn blst_p1_into_pc_g1projective(p1: &blst_p1) -> GroupProjective<g1::Parameters> {
     GroupProjective::new(
         blst_fp_into_pc_fq(&p1.x),
         blst_fp_into_pc_fq(&p1.y),
@@ -132,7 +132,7 @@ pub const fn pc_g1projective_into_blst_p1(p1: GroupProjective<g1::Parameters>) -
     }
 }
 
-pub fn blst_p2_into_pc_g2projective(p2: &P2) -> GroupProjective<g2::Parameters> {
+pub fn blst_p2_into_pc_g2projective(p2: &blst_p2) -> GroupProjective<g2::Parameters> {
     GroupProjective::new(
         blst_fp2_into_pc_fq2(&p2.x),
         blst_fp2_into_pc_fq2(&p2.y),
@@ -142,23 +142,14 @@ pub fn blst_p2_into_pc_g2projective(p2: &P2) -> GroupProjective<g2::Parameters> 
 
 pub const fn pc_g2projective_into_blst_p2(p2: GroupProjective<g2::Parameters>) -> blst_p2 {
     blst_p2 {
-        x: blst::blst_fp2 {
-            fp: [
-                blst::blst_fp { l: p2.x.c0.0 .0 },
-                blst::blst_fp { l: p2.x.c1.0 .0 },
-            ],
+        x: blst_fp2 {
+            fp: [blst_fp { l: p2.x.c0.0 .0 }, blst_fp { l: p2.x.c1.0 .0 }],
         },
-        y: blst::blst_fp2 {
-            fp: [
-                blst::blst_fp { l: p2.y.c0.0 .0 },
-                blst::blst_fp { l: p2.y.c1.0 .0 },
-            ],
+        y: blst_fp2 {
+            fp: [blst_fp { l: p2.y.c0.0 .0 }, blst_fp { l: p2.y.c1.0 .0 }],
         },
-        z: blst::blst_fp2 {
-            fp: [
-                blst::blst_fp { l: p2.z.c0.0 .0 },
-                blst::blst_fp { l: p2.z.c1.0 .0 },
-            ],
+        z: blst_fp2 {
+            fp: [blst_fp { l: p2.z.c0.0 .0 }, blst_fp { l: p2.z.c1.0 .0 }],
         },
     }
 }

--- a/blst/src/eip_4844.rs
+++ b/blst/src/eip_4844.rs
@@ -32,13 +32,15 @@ use crate::{types::kzg_settings::FsKZGSettings, utils::PRECOMPUTATION_TABLES};
 
 #[cfg(feature = "c_bindings")]
 fn kzg_settings_to_c(rust_settings: &FsKZGSettings) -> CKZGSettings {
+    use kzg::eth::c_bindings::{blst_fp, blst_fp2, blst_fr, blst_p1, blst_p2};
+
     CKZGSettings {
         roots_of_unity: Box::leak(
             rust_settings
                 .fs
                 .roots_of_unity
                 .iter()
-                .map(|r| r.0)
+                .map(|r| blst_fr { l: r.0.l })
                 .collect::<Vec<_>>()
                 .into_boxed_slice(),
         )
@@ -48,7 +50,7 @@ fn kzg_settings_to_c(rust_settings: &FsKZGSettings) -> CKZGSettings {
                 .fs
                 .brp_roots_of_unity
                 .iter()
-                .map(|r| r.0)
+                .map(|r| blst_fr { l: r.0.l })
                 .collect::<Vec<_>>()
                 .into_boxed_slice(),
         )
@@ -58,7 +60,7 @@ fn kzg_settings_to_c(rust_settings: &FsKZGSettings) -> CKZGSettings {
                 .fs
                 .reverse_roots_of_unity
                 .iter()
-                .map(|r| r.0)
+                .map(|r| blst_fr { l: r.0.l })
                 .collect::<Vec<_>>()
                 .into_boxed_slice(),
         )
@@ -67,7 +69,11 @@ fn kzg_settings_to_c(rust_settings: &FsKZGSettings) -> CKZGSettings {
             rust_settings
                 .g1_values_monomial
                 .iter()
-                .map(|r| r.0)
+                .map(|r| blst_p1 {
+                    x: blst_fp { l: r.0.x.l },
+                    y: blst_fp { l: r.0.y.l },
+                    z: blst_fp { l: r.0.z.l },
+                })
                 .collect::<Vec<_>>()
                 .into_boxed_slice(),
         )
@@ -76,7 +82,11 @@ fn kzg_settings_to_c(rust_settings: &FsKZGSettings) -> CKZGSettings {
             rust_settings
                 .g1_values_lagrange_brp
                 .iter()
-                .map(|r| r.0)
+                .map(|r| blst_p1 {
+                    x: blst_fp { l: r.0.x.l },
+                    y: blst_fp { l: r.0.y.l },
+                    z: blst_fp { l: r.0.z.l },
+                })
                 .collect::<Vec<_>>()
                 .into_boxed_slice(),
         )
@@ -85,7 +95,17 @@ fn kzg_settings_to_c(rust_settings: &FsKZGSettings) -> CKZGSettings {
             rust_settings
                 .g2_values_monomial
                 .iter()
-                .map(|r| r.0)
+                .map(|r| blst_p2 {
+                    x: blst_fp2 {
+                        fp: [blst_fp { l: r.0.x.fp[0].l }, blst_fp { l: r.0.x.fp[1].l }],
+                    },
+                    y: blst_fp2 {
+                        fp: [blst_fp { l: r.0.y.fp[0].l }, blst_fp { l: r.0.y.fp[1].l }],
+                    },
+                    z: blst_fp2 {
+                        fp: [blst_fp { l: r.0.z.fp[0].l }, blst_fp { l: r.0.z.fp[1].l }],
+                    },
+                })
                 .collect::<Vec<_>>()
                 .into_boxed_slice(),
         )
@@ -97,7 +117,11 @@ fn kzg_settings_to_c(rust_settings: &FsKZGSettings) -> CKZGSettings {
                 .map(|r| {
                     Box::leak(
                         r.iter()
-                            .map(|it| it.0)
+                            .map(|r| blst_p1 {
+                                x: blst_fp { l: r.0.x.l },
+                                y: blst_fp { l: r.0.y.l },
+                                z: blst_fp { l: r.0.z.l },
+                            })
                             .collect::<Vec<_>>()
                             .into_boxed_slice(),
                     )

--- a/blst/src/types/kzg_settings.rs
+++ b/blst/src/types/kzg_settings.rs
@@ -309,14 +309,14 @@ impl<'a> TryFrom<&'a CKZGSettings> for FsKZGSettings {
         let roots_of_unity = unsafe {
             core::slice::from_raw_parts(settings.roots_of_unity, FIELD_ELEMENTS_PER_EXT_BLOB + 1)
                 .iter()
-                .map(|r| FsFr(*r))
+                .map(|r| FsFr(blst::blst_fr { l: r.l }))
                 .collect::<Vec<FsFr>>()
         };
 
         let brp_roots_of_unity = unsafe {
             core::slice::from_raw_parts(settings.brp_roots_of_unity, FIELD_ELEMENTS_PER_EXT_BLOB)
                 .iter()
-                .map(|r| FsFr(*r))
+                .map(|r| FsFr(blst::blst_fr { l: r.l }))
                 .collect::<Vec<FsFr>>()
         };
 
@@ -326,7 +326,7 @@ impl<'a> TryFrom<&'a CKZGSettings> for FsKZGSettings {
                 FIELD_ELEMENTS_PER_EXT_BLOB + 1,
             )
             .iter()
-            .map(|r| FsFr(*r))
+            .map(|r| FsFr(blst::blst_fr { l: r.l }))
             .collect::<Vec<FsFr>>()
         };
 
@@ -347,7 +347,13 @@ impl<'a> TryFrom<&'a CKZGSettings> for FsKZGSettings {
                 )
             }
             .iter()
-            .map(|r| FsG1(*r))
+            .map(|r| {
+                FsG1(blst::blst_p1 {
+                    x: blst::blst_fp { l: r.x.l },
+                    y: blst::blst_fp { l: r.y.l },
+                    z: blst::blst_fp { l: r.z.l },
+                })
+            })
             .collect::<Vec<_>>(),
             g1_values_lagrange_brp: unsafe {
                 core::slice::from_raw_parts(
@@ -356,7 +362,13 @@ impl<'a> TryFrom<&'a CKZGSettings> for FsKZGSettings {
                 )
             }
             .iter()
-            .map(|r| FsG1(*r))
+            .map(|r| {
+                FsG1(blst::blst_p1 {
+                    x: blst::blst_fp { l: r.x.l },
+                    y: blst::blst_fp { l: r.y.l },
+                    z: blst::blst_fp { l: r.z.l },
+                })
+            })
             .collect::<Vec<_>>(),
             g2_values_monomial: unsafe {
                 core::slice::from_raw_parts(
@@ -365,7 +377,28 @@ impl<'a> TryFrom<&'a CKZGSettings> for FsKZGSettings {
                 )
             }
             .iter()
-            .map(|r| FsG2(*r))
+            .map(|r| {
+                FsG2(blst::blst_p2 {
+                    x: blst::blst_fp2 {
+                        fp: [
+                            blst::blst_fp { l: r.x.fp[0].l },
+                            blst::blst_fp { l: r.x.fp[1].l },
+                        ],
+                    },
+                    y: blst::blst_fp2 {
+                        fp: [
+                            blst::blst_fp { l: r.y.fp[0].l },
+                            blst::blst_fp { l: r.y.fp[1].l },
+                        ],
+                    },
+                    z: blst::blst_fp2 {
+                        fp: [
+                            blst::blst_fp { l: r.z.fp[0].l },
+                            blst::blst_fp { l: r.z.fp[1].l },
+                        ],
+                    },
+                })
+            })
             .collect::<Vec<_>>(),
             x_ext_fft_columns: unsafe {
                 core::slice::from_raw_parts(
@@ -377,7 +410,13 @@ impl<'a> TryFrom<&'a CKZGSettings> for FsKZGSettings {
             .map(|it| {
                 unsafe { core::slice::from_raw_parts(*it, eth::FIELD_ELEMENTS_PER_CELL) }
                     .iter()
-                    .map(|it| FsG1(*it))
+                    .map(|r| {
+                        FsG1(blst::blst_p1 {
+                            x: blst::blst_fp { l: r.x.l },
+                            y: blst::blst_fp { l: r.y.l },
+                            z: blst::blst_fp { l: r.z.l },
+                        })
+                    })
                     .collect::<Vec<_>>()
             })
             .collect::<Vec<_>>(),

--- a/constantine/src/kzg_proofs.rs
+++ b/constantine/src/kzg_proofs.rs
@@ -20,7 +20,6 @@ use crate::types::g1::CtG1ProjAddAffine;
 use kzg::msm::precompute::PrecomputationTable;
 
 use crate::types::g2::CtG2;
-use blst::{blst_p1_affine, blst_p1_cneg, blst_p1_to_affine, blst_p2_affine, blst_p2_to_affine};
 
 use kzg::PairingVerify;
 
@@ -85,22 +84,22 @@ pub fn g1_linear_combination(
 
 pub fn pairings_verify(a1: &CtG1, a2: &CtG2, b1: &CtG1, b2: &CtG2) -> bool {
     // FIXME: Remove usage of BLST version, though not sure if there's a constantine version of multi miller loop
-    let mut aa1 = blst_p1_affine::default();
-    let mut bb1 = blst_p1_affine::default();
+    let mut aa1 = blst::blst_p1_affine::default();
+    let mut bb1 = blst::blst_p1_affine::default();
 
-    let mut aa2 = blst_p2_affine::default();
-    let mut bb2 = blst_p2_affine::default();
+    let mut aa2 = blst::blst_p2_affine::default();
+    let mut bb2 = blst::blst_p2_affine::default();
 
     // As an optimisation, we want to invert one of the pairings,
     // so we negate one of the points.
     let mut a1neg: CtG1 = *a1;
     unsafe {
-        blst_p1_cneg(ptr_transmute_mut(&mut a1neg.0), true);
-        blst_p1_to_affine(&mut aa1, ptr_transmute(&a1neg.0));
+        blst::blst_p1_cneg(ptr_transmute_mut(&mut a1neg.0), true);
+        blst::blst_p1_to_affine(&mut aa1, ptr_transmute(&a1neg.0));
 
-        blst_p1_to_affine(&mut bb1, ptr_transmute(&b1.0));
-        blst_p2_to_affine(&mut aa2, ptr_transmute(&a2.0));
-        blst_p2_to_affine(&mut bb2, ptr_transmute(&b2.0));
+        blst::blst_p1_to_affine(&mut bb1, ptr_transmute(&b1.0));
+        blst::blst_p2_to_affine(&mut aa2, ptr_transmute(&a2.0));
+        blst::blst_p2_to_affine(&mut bb2, ptr_transmute(&b2.0));
 
         let dst = [0u8; 3];
         let mut pairing_blst = blst::Pairing::new(false, &dst);

--- a/constantine/src/types/fr.rs
+++ b/constantine/src/types/fr.rs
@@ -5,10 +5,10 @@ use alloc::format;
 use alloc::string::String;
 use alloc::string::ToString;
 
-use blst::blst_fr;
 use constantine::ctt_codec_scalar_status;
 use core::fmt::{Debug, Formatter};
 use kzg::eip_4844::BYTES_PER_FIELD_ELEMENT;
+use kzg::eth::c_bindings::blst_fr;
 use kzg::Fr;
 use kzg::Scalar256;
 
@@ -37,7 +37,7 @@ impl PartialEq for CtFr {
 impl Eq for CtFr {}
 
 impl CtFr {
-    pub fn from_blst_fr(fr: blst::blst_fr) -> Self {
+    pub fn from_blst_fr(fr: blst_fr) -> Self {
         unsafe {
             Self(bls12_381_fr {
                 limbs: core::mem::transmute::<[u64; 4], [usize; 4]>(fr.l),

--- a/constantine/src/types/g1.rs
+++ b/constantine/src/types/g1.rs
@@ -4,6 +4,8 @@ use alloc::format;
 use alloc::string::String;
 use alloc::string::ToString;
 use constantine::ctt_codec_ecc_status;
+use kzg::eth::c_bindings::blst_fp;
+use kzg::eth::c_bindings::blst_p1;
 use kzg::msm::precompute::PrecomputationTable;
 use kzg::G1LinComb;
 
@@ -53,7 +55,7 @@ impl CtG1 {
         CtG1(bls12_381_g1_jac { x, y, z })
     }
 
-    pub const fn from_blst_p1(p1: blst::blst_p1) -> Self {
+    pub const fn from_blst_p1(p1: blst_p1) -> Self {
         unsafe {
             Self(bls12_381_g1_jac {
                 x: bls12_381_fp {
@@ -69,16 +71,16 @@ impl CtG1 {
         }
     }
 
-    pub const fn to_blst_p1(&self) -> blst::blst_p1 {
+    pub const fn to_blst_p1(&self) -> blst_p1 {
         unsafe {
-            blst::blst_p1 {
-                x: blst::blst_fp {
+            blst_p1 {
+                x: blst_fp {
                     l: core::mem::transmute::<[usize; 6], [u64; 6]>(self.0.x.limbs),
                 },
-                y: blst::blst_fp {
+                y: blst_fp {
                     l: core::mem::transmute::<[usize; 6], [u64; 6]>(self.0.y.limbs),
                 },
-                z: blst::blst_fp {
+                z: blst_fp {
                     l: core::mem::transmute::<[usize; 6], [u64; 6]>(self.0.z.limbs),
                 },
             }

--- a/constantine/src/types/g2.rs
+++ b/constantine/src/types/g2.rs
@@ -20,11 +20,13 @@ use constantine_sys::{
 
 use constantine_sys as constantine;
 
+use kzg::eth::c_bindings::{blst_fp, blst_fp2, blst_p2};
+
 #[derive(Default, Clone, Copy)]
 pub struct CtG2(pub bls12_381_g2_jac);
 
 impl CtG2 {
-    pub const fn from_blst_p2(p2: blst::blst_p2) -> Self {
+    pub const fn from_blst_p2(p2: blst_p2) -> Self {
         unsafe {
             Self(bls12_381_g2_jac {
                 x: bls12_381_fp2 {
@@ -61,35 +63,35 @@ impl CtG2 {
         }
     }
 
-    pub const fn to_blst_p2(&self) -> blst::blst_p2 {
+    pub const fn to_blst_p2(&self) -> blst_p2 {
         unsafe {
-            blst::blst_p2 {
-                x: blst::blst_fp2 {
+            blst_p2 {
+                x: blst_fp2 {
                     fp: [
-                        blst::blst_fp {
+                        blst_fp {
                             l: core::mem::transmute::<[usize; 6], [u64; 6]>(self.0.x.c[0].limbs),
                         },
-                        blst::blst_fp {
+                        blst_fp {
                             l: core::mem::transmute::<[usize; 6], [u64; 6]>(self.0.x.c[1].limbs),
                         },
                     ],
                 },
-                y: blst::blst_fp2 {
+                y: blst_fp2 {
                     fp: [
-                        blst::blst_fp {
+                        blst_fp {
                             l: core::mem::transmute::<[usize; 6], [u64; 6]>(self.0.y.c[0].limbs),
                         },
-                        blst::blst_fp {
+                        blst_fp {
                             l: core::mem::transmute::<[usize; 6], [u64; 6]>(self.0.y.c[1].limbs),
                         },
                     ],
                 },
-                z: blst::blst_fp2 {
+                z: blst_fp2 {
                     fp: [
-                        blst::blst_fp {
+                        blst_fp {
                             l: core::mem::transmute::<[usize; 6], [u64; 6]>(self.0.z.c[0].limbs),
                         },
-                        blst::blst_fp {
+                        blst_fp {
                             l: core::mem::transmute::<[usize; 6], [u64; 6]>(self.0.z.c[1].limbs),
                         },
                     ],

--- a/kzg/Cargo.toml
+++ b/kzg/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-blst = "0.3.11"
 sha2 = { version = "0.10.6", default-features = false }
 num_cpus = { version = "1.16.0", optional = true }
 rayon = { version = "1.8.0", optional = true } 

--- a/kzg/src/eip_4844.rs
+++ b/kzg/src/eip_4844.rs
@@ -18,7 +18,6 @@ use alloc::string::ToString;
 use alloc::sync::Arc;
 use alloc::vec;
 use alloc::vec::Vec;
-pub use blst::{blst_fr, blst_p1, blst_p2};
 use core::hash::Hash;
 use core::hash::Hasher;
 use sha2::{Digest, Sha256};

--- a/kzg/src/eth/c_bindings.rs
+++ b/kzg/src/eth/c_bindings.rs
@@ -1,5 +1,3 @@
-use blst::{blst_fr, blst_p1, blst_p1_affine, blst_p2};
-
 use crate::{
     eth::{CELLS_PER_EXT_BLOB, FIELD_ELEMENTS_PER_CELL},
     EcBackend, Fr, DAS, G1,
@@ -420,4 +418,57 @@ macro_rules! c_bindings_eip7594 {
             )
         }
     };
+}
+
+// Below types are copied from `blst` crate.
+// It is needed so other backends do not depend on blst runtime, but still can
+// provide c-kzg-4844 compatible apis.
+#[allow(non_camel_case_types)]
+pub type limb_t = u64;
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
+#[allow(non_camel_case_types)]
+pub struct blst_fr {
+    pub l: [limb_t; 4usize],
+}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
+#[allow(non_camel_case_types)]
+pub struct blst_p1 {
+    pub x: blst_fp,
+    pub y: blst_fp,
+    pub z: blst_fp,
+}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
+#[allow(non_camel_case_types)]
+pub struct blst_fp {
+    pub l: [limb_t; 6usize],
+}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
+#[allow(non_camel_case_types)]
+pub struct blst_p2 {
+    pub x: blst_fp2,
+    pub y: blst_fp2,
+    pub z: blst_fp2,
+}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
+#[allow(non_camel_case_types)]
+pub struct blst_fp2 {
+    pub fp: [blst_fp; 2usize],
+}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
+#[allow(non_camel_case_types)]
+pub struct blst_p1_affine {
+    pub x: blst_fp,
+    pub y: blst_fp,
 }

--- a/zkcrypto/Cargo.toml
+++ b/zkcrypto/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-blst = "0.3.11"
 kzg = { path = "../kzg", default-features = false }
 bls12_381 = { path = "../zkcrypto/bls12_381" }
 ff = { version = "0.13", features = ["derive"] }

--- a/zkcrypto/src/kzg_types.rs
+++ b/zkcrypto/src/kzg_types.rs
@@ -13,11 +13,10 @@ use crate::utils::{
     pc_g2projective_into_blst_p2, PRECOMPUTATION_TABLES,
 };
 use bls12_381::{Fp, G1Affine, G1Projective, G2Affine, G2Projective, Scalar, MODULUS, R2};
-use blst::{blst_fr, blst_p1};
 use ff::Field;
 use kzg::common_utils::reverse_bit_order;
 use kzg::eip_4844::{BYTES_PER_FIELD_ELEMENT, BYTES_PER_G1, BYTES_PER_G2};
-use kzg::eth::c_bindings::CKZGSettings;
+use kzg::eth::c_bindings::{blst_fr, blst_p1, blst_p2, CKZGSettings};
 use kzg::msm::precompute::{precompute, PrecomputationTable};
 use kzg::{eth, G1Affine as G1AffineTrait};
 use kzg::{
@@ -679,7 +678,7 @@ pub struct ZG2 {
 }
 
 impl ZG2 {
-    pub const fn from_blst_p2(p2: blst::blst_p2) -> Self {
+    pub const fn from_blst_p2(p2: blst_p2) -> Self {
         Self {
             proj: blst_p2_into_pc_g2projective(&p2),
         }
@@ -687,7 +686,7 @@ impl ZG2 {
     pub const fn from_g2_projective(proj: G2Projective) -> Self {
         Self { proj }
     }
-    pub const fn to_blst_p2(&self) -> blst::blst_p2 {
+    pub const fn to_blst_p2(&self) -> blst_p2 {
         pc_g2projective_into_blst_p2(self.proj)
     }
 }

--- a/zkcrypto/src/lib.rs
+++ b/zkcrypto/src/lib.rs
@@ -1,14 +1,3 @@
-pub type Pairing = blst::Pairing;
-pub type Fp = blst::blst_fp;
-pub type Fp12 = blst::blst_fp12;
-pub type Fp6 = blst::blst_fp6;
-pub type Fr = blst::blst_fr;
-pub type P1 = blst::blst_p1;
-pub type P1Affine = blst::blst_p1_affine;
-pub type P2 = blst::blst_p2;
-pub type P2Affine = blst::blst_p2_affine;
-pub type Scalar = blst::blst_scalar;
-pub type Uniq = blst::blst_uniq;
 pub mod consts;
 pub mod das;
 pub mod eip_4844;

--- a/zkcrypto/src/utils.rs
+++ b/zkcrypto/src/utils.rs
@@ -1,14 +1,14 @@
-use super::P1;
 use crate::{
     kzg_proofs::FFTSettings,
     kzg_types::{ZFp, ZFr, ZG1Affine, ZG1},
-    P2,
 };
 use bls12_381::{G1Projective, G2Projective, Scalar};
-use blst::{blst_fp, blst_fp2, blst_fr, blst_p1, blst_p2};
 use kzg::{
     eip_4844::PrecomputationTableManager,
-    eth::{self, c_bindings::CKZGSettings},
+    eth::{
+        self,
+        c_bindings::{blst_fp, blst_fp2, blst_fr, blst_p1, blst_p2, CKZGSettings},
+    },
 };
 
 #[derive(Debug, PartialEq, Eq)]
@@ -26,7 +26,7 @@ pub const fn blst_fp2_into_pc_fq2(fp: &blst_fp2) -> bls12_381::Fp2 {
     bls12_381::Fp2 { c0, c1 }
 }
 
-pub const fn blst_p1_into_pc_g1projective(p1: &P1) -> G1Projective {
+pub const fn blst_p1_into_pc_g1projective(p1: &blst_p1) -> G1Projective {
     let x = bls12_381::Fp(p1.x.l);
     let y = bls12_381::Fp(p1.y.l);
     let z = bls12_381::Fp(p1.z.l);
@@ -41,7 +41,7 @@ pub const fn pc_g1projective_into_blst_p1(p1: G1Projective) -> blst_p1 {
     blst_p1 { x, y, z }
 }
 
-pub const fn blst_p2_into_pc_g2projective(p2: &P2) -> G2Projective {
+pub const fn blst_p2_into_pc_g2projective(p2: &blst_p2) -> G2Projective {
     G2Projective {
         x: blst_fp2_into_pc_fq2(&p2.x),
         y: blst_fp2_into_pc_fq2(&p2.y),


### PR DESCRIPTION
In this PR:
* Removed `blst` dependency from `kzg`, `zkcrypto` and `arkworks` backends. 
* Copied blst structures into kzg crate
* `arkworks3` and `constantine` backends still depend on `blst`, as there are still several problems unsolved:
    * in constantine backend, pairings are calculated via blst.
    * in arkworks3 backend, G1 & G2 serialization/deserialization is done via blst
    
  Those two problems need to be solved, to remove `blst` dependency.

This PR is needed for https://github.com/grandinetech/grandine/issues/74