### PR TITLE
Enable peer das benchmarks for arkworks, arkworks3 and zkcrypto backends

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -165,14 +165,14 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --manifest-path ${{ matrix.backend }}/Cargo.toml --no-fail-fast --release
+          args: --manifest-path ${{ matrix.backend }}/Cargo.toml --no-fail-fast --release --features c_bindings
 
       # Check parallel backend tests
       - name: "${{ matrix.backend }} Tests (parallel)"
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --manifest-path ${{ matrix.backend }}/Cargo.toml --no-fail-fast --release --features parallel
+          args: --manifest-path ${{ matrix.backend }}/Cargo.toml --no-fail-fast --release --features c_bindings,parallel
 
       # Check ckzg backend tests
       - name: "${{ matrix.backend }} Tests (c-kzg-4844)"

--- a/arkworks/Cargo.toml
+++ b/arkworks/Cargo.toml
@@ -82,5 +82,9 @@ name = "eip_4844"
 harness = false
 
 [[bench]]
+name = "eip_7594"
+harness = false
+
+[[bench]]
 name = "lincomb"
 harness = false

--- a/arkworks/benches/eip_7594.rs
+++ b/arkworks/benches/eip_7594.rs
@@ -1,0 +1,16 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use kzg::eip_4844::{blob_to_kzg_commitment_rust, bytes_to_blob};
+use kzg_bench::benches::eip_7594::bench_eip_7594;
+use rust_kzg_arkworks::{eip_4844::load_trusted_setup_filename_rust, eip_7594::ArkBackend};
+
+fn bench_eip_7594_(c: &mut Criterion) {
+    bench_eip_7594::<ArkBackend>(
+        c,
+        &load_trusted_setup_filename_rust,
+        &bytes_to_blob,
+        &blob_to_kzg_commitment_rust,
+    );
+}
+
+criterion_group!(benches, bench_eip_7594_);
+criterion_main!(benches);

--- a/arkworks3/Cargo.toml
+++ b/arkworks3/Cargo.toml
@@ -85,5 +85,9 @@ name = "eip_4844"
 harness = false
 
 [[bench]]
+name = "eip_7594"
+harness = false
+
+[[bench]]
 name = "lincomb"
 harness = false

--- a/arkworks3/benches/eip_7594.rs
+++ b/arkworks3/benches/eip_7594.rs
@@ -1,0 +1,16 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use kzg::eip_4844::{blob_to_kzg_commitment_rust, bytes_to_blob};
+use kzg_bench::benches::eip_7594::bench_eip_7594;
+use rust_kzg_arkworks3::{eip_4844::load_trusted_setup_filename_rust, eip_7594::ArkBackend};
+
+fn bench_eip_7594_(c: &mut Criterion) {
+    bench_eip_7594::<ArkBackend>(
+        c,
+        &load_trusted_setup_filename_rust,
+        &bytes_to_blob,
+        &blob_to_kzg_commitment_rust,
+    );
+}
+
+criterion_group!(benches, bench_eip_7594_);
+criterion_main!(benches);

--- a/zkcrypto/Cargo.toml
+++ b/zkcrypto/Cargo.toml
@@ -71,6 +71,10 @@ name = "eip_4844"
 harness = false
 
 [[bench]]
+name = "eip_7594"
+harness = false
+
+[[bench]]
 name = "lincomb"
 harness = false
 

--- a/zkcrypto/benches/eip_7594.rs
+++ b/zkcrypto/benches/eip_7594.rs
@@ -1,0 +1,16 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use kzg::eip_4844::{blob_to_kzg_commitment_rust, bytes_to_blob};
+use kzg_bench::benches::eip_7594::bench_eip_7594;
+use rust_kzg_zkcrypto::{eip_4844::load_trusted_setup_filename_rust, eip_7594::ZBackend};
+
+fn bench_eip_7594_(c: &mut Criterion) {
+    bench_eip_7594::<ZBackend>(
+        c,
+        &load_trusted_setup_filename_rust,
+        &bytes_to_blob,
+        &blob_to_kzg_commitment_rust,
+    );
+}
+
+criterion_group!(benches, bench_eip_7594_);
+criterion_main!(benches);


### PR DESCRIPTION
In this PR:
* Added EIP-7594 benchmarks for `arkworks`, `arkworks3` & `zkcrypto` backends
* Enabled `c_bindings` feature, when running tests in CI - in #278 we've decided to disable this feature by default, but some tests depend on it and I forgot to enable it back :)