### PR TITLE
PeerDAS: Add raw functions like eip4844

### DIFF
--- a/kzg/src/common_utils.rs
+++ b/kzg/src/common_utils.rs
@@ -95,3 +95,45 @@ pub fn reverse_bits_limited(length: usize, value: usize) -> usize {
     let unused_bits = length.leading_zeros() + 1;
     value.reverse_bits() >> unused_bits
 }
+
+#[macro_export]
+macro_rules! cfg_iter_mut {
+    ($collection:expr) => {{
+        #[cfg(feature = "parallel")]
+        {
+            $collection.par_iter_mut()
+        }
+        #[cfg(not(feature = "parallel"))]
+        {
+            $collection.iter_mut()
+        }
+    }};
+}
+
+#[macro_export]
+macro_rules! cfg_iter {
+    ($collection:expr) => {{
+        #[cfg(feature = "parallel")]
+        {
+            $collection.par_iter()
+        }
+        #[cfg(not(feature = "parallel"))]
+        {
+            $collection.iter()
+        }
+    }};
+}
+
+#[macro_export]
+macro_rules! cfg_chunks {
+    ($collection:expr, $chunk_size:expr) => {{
+        #[cfg(feature = "parallel")]
+        {
+            $collection.par_chunks($chunk_size)
+        }
+        #[cfg(not(feature = "parallel"))]
+        {
+            $collection.chunks($chunk_size)
+        }
+    }};
+}

--- a/kzg/src/das.rs
+++ b/kzg/src/das.rs
@@ -10,6 +10,7 @@ use alloc::{
 };
 
 use crate::{
+    cfg_iter, cfg_iter_mut,
     common_utils::{reverse_bit_order, reverse_bits_limited},
     eip_4844::{
         blob_to_polynomial, compute_powers, hash, hash_to_bls_field, BYTES_PER_COMMITMENT,
@@ -20,32 +21,6 @@ use crate::{
 };
 
 pub const RANDOM_CHALLENGE_KZG_CELL_BATCH_DOMAIN: [u8; 16] = *b"RCKZGCBATCH__V1_";
-
-macro_rules! cfg_iter_mut {
-    ($collection:expr) => {{
-        #[cfg(feature = "parallel")]
-        {
-            $collection.par_iter_mut()
-        }
-        #[cfg(not(feature = "parallel"))]
-        {
-            $collection.iter_mut()
-        }
-    }};
-}
-
-macro_rules! cfg_iter {
-    ($collection:expr) => {{
-        #[cfg(feature = "parallel")]
-        {
-            $collection.par_iter()
-        }
-        #[cfg(not(feature = "parallel"))]
-        {
-            $collection.iter()
-        }
-    }};
-}
 
 pub trait EcBackend {
     type Fr: Fr + Debug + Send;

--- a/kzg/src/eth/eip_7594.rs
+++ b/kzg/src/eth/eip_7594.rs
@@ -1,0 +1,125 @@
+#[cfg(feature = "parallel")]
+use rayon::prelude::*;
+
+use alloc::{format, string::String, vec::Vec};
+
+use crate::{
+    cfg_chunks, cfg_iter,
+    das::{EcBackend, DAS},
+    eip_4844::bytes_to_blob,
+    eth::{
+        BYTES_PER_BLOB, BYTES_PER_CELL, BYTES_PER_COMMITMENT, BYTES_PER_FIELD_ELEMENT,
+        BYTES_PER_PROOF, CELLS_PER_EXT_BLOB, FIELD_ELEMENTS_PER_CELL, FIELD_ELEMENTS_PER_EXT_BLOB,
+    },
+    Fr, G1,
+};
+
+pub type CellsKzgProofs = (Vec<[u8; BYTES_PER_CELL]>, Vec<[u8; BYTES_PER_PROOF]>);
+
+pub fn recover_cells_and_kzg_proofs_raw<B: EcBackend>(
+    cell_indices: &[usize],
+    cells: &[[u8; BYTES_PER_CELL]],
+    das: &impl DAS<B>,
+) -> Result<CellsKzgProofs, String>
+where
+    B::G1: Copy,
+    B::Fr: Copy,
+{
+    let cells = cfg_chunks!(cells.as_flattened(), BYTES_PER_FIELD_ELEMENT)
+        .map(B::Fr::from_bytes)
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let mut recovered_cells = [B::Fr::default(); FIELD_ELEMENTS_PER_EXT_BLOB];
+    let mut recovered_proofs = [B::G1::default(); CELLS_PER_EXT_BLOB];
+
+    das.recover_cells_and_kzg_proofs(
+        &mut recovered_cells,
+        Some(&mut recovered_proofs),
+        cell_indices,
+        &cells,
+    )?;
+
+    let converted_cells = cells_elements_to_cells_bytes::<B>(&recovered_cells)?;
+    let converted_proofs = recovered_proofs
+        .into_iter()
+        .map(|proof| proof.to_bytes())
+        .collect::<Vec<_>>();
+
+    Ok((converted_cells, converted_proofs))
+}
+
+pub fn compute_cells_and_kzg_proofs_raw<B: EcBackend>(
+    blob: [u8; BYTES_PER_BLOB],
+    das: &impl DAS<B>,
+) -> Result<CellsKzgProofs, String>
+where
+    B::G1: Copy,
+    B::Fr: Copy,
+{
+    let blob = bytes_to_blob(&blob)?;
+
+    let mut recovered_cells = [B::Fr::default(); FIELD_ELEMENTS_PER_EXT_BLOB];
+    let mut recovered_proofs = [B::G1::default(); CELLS_PER_EXT_BLOB];
+
+    das.compute_cells_and_kzg_proofs(
+        Some(&mut recovered_cells),
+        Some(&mut recovered_proofs),
+        &blob,
+    )?;
+
+    let converted_cells = cells_elements_to_cells_bytes::<B>(&recovered_cells)?;
+    let converted_proofs = recovered_proofs
+        .into_iter()
+        .map(|proof| proof.to_bytes())
+        .collect::<Vec<_>>();
+
+    Ok((converted_cells, converted_proofs))
+}
+
+pub fn verify_cell_kzg_proof_batch_raw<B: EcBackend>(
+    commitments: &[[u8; BYTES_PER_COMMITMENT]],
+    cell_indices: &[usize],
+    cells: &[[u8; BYTES_PER_CELL]],
+    proofs: &[[u8; BYTES_PER_PROOF]],
+    das: &impl DAS<B>,
+) -> Result<bool, String> {
+    let commitments = cfg_iter!(commitments)
+        .map(|commitment| B::G1::from_bytes(commitment))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let cells = cfg_chunks!(cells.as_flattened(), BYTES_PER_FIELD_ELEMENT)
+        .map(B::Fr::from_bytes)
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let proofs = cfg_iter!(proofs)
+        .map(|proof| B::G1::from_bytes(proof))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    das.verify_cell_kzg_proof_batch(&commitments, cell_indices, &cells, &proofs)
+}
+
+fn cells_elements_to_cells_bytes<B: EcBackend>(
+    bytes: &[B::Fr],
+) -> Result<Vec<[u8; BYTES_PER_CELL]>, String> {
+    // NOTE: chunk_size = BYTES_PER_CELL / BYTES_PER_FIELD_ELEMENT
+    if bytes.len() != FIELD_ELEMENTS_PER_EXT_BLOB {
+        return Err(format!(
+            "Invalid field elements length. Expected {} got {}",
+            FIELD_ELEMENTS_PER_EXT_BLOB,
+            bytes.len(),
+        ));
+    }
+
+    Ok(cfg_chunks!(bytes, FIELD_ELEMENTS_PER_CELL)
+        .map(|cell_bytes| {
+            let mut result = [0u8; BYTES_PER_CELL];
+            for (idx, field_element) in cell_bytes.iter().enumerate() {
+                let bytes_element = field_element.to_bytes();
+                let start = idx * BYTES_PER_FIELD_ELEMENT;
+                let end = start + BYTES_PER_FIELD_ELEMENT;
+                result[start..end].copy_from_slice(&bytes_element);
+            }
+            result
+        })
+        .collect())
+}

--- a/kzg/src/eth/mod.rs
+++ b/kzg/src/eth/mod.rs
@@ -1,4 +1,5 @@
 pub mod c_bindings;
+pub mod eip_7594;
 
 pub const FIELD_ELEMENTS_PER_BLOB: usize = 4096;
 pub const BYTES_PER_G1: usize = 48;


### PR DESCRIPTION
This pull request will add raw functions into DAS trait, like eip4844 in this [commit](https://github.com/grandinetech/rust-kzg/commit/6d33a883a1c552e1e10ca4e56249a18f4c8fed90#diff-70df151cb548dfa1811d5c198927567fb09e94e7b7b0c11a3326a0a9fcaf9570). The idea is to allow easier integration into its domain without needing to transform unit type into underlying field element type (e.g. converting [`Cell`](https://github.com/ethereum/consensus-specs/blob/b1c70a96883feddb194eba4f3a033a8b53f0d082/specs/fulu/polynomial-commitments-sampling.md?plain=1#L74) into field elements), which adding more complexity into the integration. The WIP integration into `grandine` can be found [here](https://github.com/hangleang/grandine/tree/rust-kzg-integration).

NOTE: the current changes has a few bugs (potential issues have been marked as well), which give the following error when test in the integration:

```
source slice length (8192) does not match destination slice length (0)
```

the error is pointing to [kzg/src/das.rs](https://github.com/hangleang/rust-kzg/blob/6948344244b6e14752335aebcca0e4f993846478/kzg/src/das.rs#L277), which I'm not quite familiar with the logic here.

**UPDATED: the bug has been fixed, after creating the issue :)**

cc @ArtiomTr, please help review the changes and give some suggestions