### PR TITLE
Fixed automatic release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
           zip -rz ${{ env.archive-name }} * <<< "Compatible with c-kzg-4844 git hash: $C_KZG_4844_GIT_HASH."
 
       - name: "${{ env.matrix-name }} Upload"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.archive-name }}
           path: ${{ env.staging-dir }}/${{ env.archive-name }}
@@ -81,7 +81,7 @@ jobs:
     needs: release-build
     steps:
     - name: Download build artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
     - uses: "marvinpinto/action-automatic-releases@latest"
       with:
         repo_token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
actions/upload-artifact@v3 and actions/download-artifact@v3 [are deprecated](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/), and currently fail on main branch.

This PR updates them to `v4`.