### PR TITLE
Updated sppark to 0.1.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1800,9 +1800,9 @@ checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "sppark"
-version = "0.1.6"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb266b15daead53670d477d7e136b8fc92d46e31bb9007ac46d304df23689a4b"
+checksum = "16bf457036c0a778140ce4c3bcf9ff30c5c70a9d9c0bb04fe513af025b647b2c"
 dependencies = [
  "cc",
  "which",

--- a/arkworks3-sppark/Cargo.toml
+++ b/arkworks3-sppark/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 blst = "0.3.11"
-sppark = "0.1.6"
+sppark = "0.1.11"
 ark-std = "0.3.0"
 ark-ff = "0.3.0"
 ark-ec = { version = "0.3.0", features = [ "parallel" ] }

--- a/arkworks3-sppark/cuda/pippenger.cu
+++ b/arkworks3-sppark/cuda/pippenger.cu
@@ -9,6 +9,8 @@
 #include <ec/jacobian_t.hpp>
 #include <ec/xyzz_t.hpp>
 
+using namespace bls12_381;
+
 typedef jacobian_t<fp_t> point_t;
 typedef xyzz_t<fp_t> bucket_t;
 typedef bucket_t::affine_inf_t affine_t;

--- a/blst-sppark/Cargo.toml
+++ b/blst-sppark/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 blst = "0.3.11"
-sppark = "0.1.6"
+sppark = "0.1.11"
 
 [build-dependencies]
 cc = "^1.0.70"

--- a/blst-sppark/cuda/pippenger.cu
+++ b/blst-sppark/cuda/pippenger.cu
@@ -9,6 +9,8 @@
 #include <ec/jacobian_t.hpp>
 #include <ec/xyzz_t.hpp>
 
+using namespace bls12_381;
+
 typedef jacobian_t<fp_t> point_t;
 typedef xyzz_t<fp_t> bucket_t;
 typedef bucket_t::affine_t affine_t;


### PR DESCRIPTION
This PR:
* Updates sppark to latest version `0.1.11`.

Needed for GPU-accelerated backend integration in https://github.com/grandinetech/grandine/pull/88