### PR TITLE
Optimize PeerDAS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1020,6 +1020,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1102,6 +1108,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 dependencies = [
  "allocator-api2",
+ "equivalent",
+ "foldhash",
 ]
 
 [[package]]
@@ -1207,6 +1215,7 @@ dependencies = [
 name = "kzg"
 version = "0.1.0"
 dependencies = [
+ "hashbrown 0.15.2",
  "num_cpus",
  "rayon",
  "sha2 0.10.8",

--- a/arkworks3/src/kzg_types.rs
+++ b/arkworks3/src/kzg_types.rs
@@ -232,7 +232,7 @@ impl KzgFr for ArkFr {
 }
 
 #[repr(C)]
-#[derive(Debug, Default, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, Default, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct ArkG1(pub GroupProjective<g1::Parameters>);
 
 impl ArkG1 {

--- a/arkworks3/src/kzg_types.rs
+++ b/arkworks3/src/kzg_types.rs
@@ -951,7 +951,6 @@ impl KZGSettings<ArkFr, ArkG1, ArkG2, LFFTSettings, PolyData, ArkFp, ArkG1Affine
             g1_values_lagrange_brp: g1_lagrange_brp.to_vec(),
             g2_values_monomial: g2_monomial.to_vec(),
             fs: fft_settings.clone(),
-            x_ext_fft_columns,
             precomputation: {
                 #[cfg(feature = "sppark")]
                 {
@@ -988,9 +987,13 @@ impl KZGSettings<ArkFr, ArkG1, ArkG2, LFFTSettings, PolyData, ArkFp, ArkG1Affine
 
                 #[cfg(not(any(feature = "sppark", feature = "sppark_wlc")))]
                 {
-                    precompute(g1_lagrange_brp).ok().flatten().map(Arc::new)
+                    precompute(g1_lagrange_brp, &x_ext_fft_columns)
+                        .ok()
+                        .flatten()
+                        .map(Arc::new)
                 }
             },
+            x_ext_fft_columns,
             cell_size,
         })
     }
@@ -1162,8 +1165,8 @@ impl KZGSettings<ArkFr, ArkG1, ArkG2, LFFTSettings, PolyData, ArkFp, ArkG1Affine
         &self.g2_values_monomial
     }
 
-    fn get_x_ext_fft_column(&self, index: usize) -> &[ArkG1] {
-        &self.x_ext_fft_columns[index]
+    fn get_x_ext_fft_columns(&self) -> &[Vec<ArkG1>] {
+        &self.x_ext_fft_columns
     }
 
     fn get_cell_size(&self) -> usize {

--- a/arkworks4/src/kzg_types.rs
+++ b/arkworks4/src/kzg_types.rs
@@ -252,7 +252,7 @@ impl KzgFr for ArkFr {
 }
 
 #[repr(C)]
-#[derive(Debug, Default, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, Default, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct ArkG1(pub Projective<g1::Config>);
 
 impl ArkG1 {

--- a/arkworks4/src/kzg_types.rs
+++ b/arkworks4/src/kzg_types.rs
@@ -697,8 +697,11 @@ impl KZGSettings<ArkFr, ArkG1, ArkG2, LFFTSettings, PolyData, ArkFp, ArkG1Affine
             g1_values_lagrange_brp: g1_lagrange_brp.to_vec(),
             g2_values_monomial: g2_monomial.to_vec(),
             fs: fft_settings.clone(),
+            precomputation: precompute(g1_lagrange_brp, &x_ext_fft_columns)
+                .ok()
+                .flatten()
+                .map(Arc::new),
             x_ext_fft_columns,
-            precomputation: precompute(g1_lagrange_brp).ok().flatten().map(Arc::new),
             cell_size,
         })
     }
@@ -865,8 +868,8 @@ impl KZGSettings<ArkFr, ArkG1, ArkG2, LFFTSettings, PolyData, ArkFp, ArkG1Affine
         self.precomputation.as_ref().map(|v| v.as_ref())
     }
 
-    fn get_x_ext_fft_column(&self, index: usize) -> &[ArkG1] {
-        &self.x_ext_fft_columns[index]
+    fn get_x_ext_fft_columns(&self) -> &[Vec<ArkG1>] {
+        &self.x_ext_fft_columns
     }
 
     fn get_cell_size(&self) -> usize {

--- a/arkworks5/src/kzg_types.rs
+++ b/arkworks5/src/kzg_types.rs
@@ -252,7 +252,7 @@ impl KzgFr for ArkFr {
 }
 
 #[repr(C)]
-#[derive(Debug, Default, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, Default, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct ArkG1(pub Projective<g1::Config>);
 
 impl ArkG1 {

--- a/arkworks5/src/kzg_types.rs
+++ b/arkworks5/src/kzg_types.rs
@@ -697,8 +697,11 @@ impl KZGSettings<ArkFr, ArkG1, ArkG2, LFFTSettings, PolyData, ArkFp, ArkG1Affine
             g1_values_lagrange_brp: g1_lagrange_brp.to_vec(),
             g2_values_monomial: g2_monomial.to_vec(),
             fs: fft_settings.clone(),
+            precomputation: precompute(g1_lagrange_brp, &x_ext_fft_columns)
+                .ok()
+                .flatten()
+                .map(Arc::new),
             x_ext_fft_columns,
-            precomputation: precompute(g1_lagrange_brp).ok().flatten().map(Arc::new),
             cell_size,
         })
     }
@@ -865,8 +868,8 @@ impl KZGSettings<ArkFr, ArkG1, ArkG2, LFFTSettings, PolyData, ArkFp, ArkG1Affine
         self.precomputation.as_ref().map(|v| v.as_ref())
     }
 
-    fn get_x_ext_fft_column(&self, index: usize) -> &[ArkG1] {
-        &self.x_ext_fft_columns[index]
+    fn get_x_ext_fft_columns(&self) -> &[Vec<ArkG1>] {
+        &self.x_ext_fft_columns
     }
 
     fn get_cell_size(&self) -> usize {

--- a/blst/src/types/g1.rs
+++ b/blst/src/types/g1.rs
@@ -1,5 +1,6 @@
 extern crate alloc;
 
+use core::hash::Hash;
 use core::ptr;
 
 use alloc::format;
@@ -31,6 +32,14 @@ use super::fp::FsFp;
 #[repr(C)]
 #[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
 pub struct FsG1(pub blst_p1);
+
+impl Hash for FsG1 {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        self.0.x.l.hash(state);
+        self.0.y.l.hash(state);
+        self.0.z.l.hash(state);
+    }
+}
 
 impl FsG1 {
     pub(crate) const fn from_xyz(x: blst_fp, y: blst_fp, z: blst_fp) -> Self {

--- a/blst/src/types/kzg_settings.rs
+++ b/blst/src/types/kzg_settings.rs
@@ -101,7 +101,6 @@ impl KZGSettings<FsFr, FsG1, FsG2, FsFFTSettings, FsPoly, FsFp, FsG1Affine> for 
             g1_values_lagrange_brp: g1_lagrange_brp.to_vec(),
             g2_values_monomial: g2_monomial.to_vec(),
             fs: fft_settings.clone(),
-            x_ext_fft_columns,
             precomputation: {
                 #[cfg(feature = "sppark")]
                 {
@@ -121,9 +120,13 @@ impl KZGSettings<FsFr, FsG1, FsG2, FsFFTSettings, FsPoly, FsFp, FsG1Affine> for 
 
                 #[cfg(not(feature = "sppark"))]
                 {
-                    precompute(g1_lagrange_brp).ok().flatten().map(Arc::new)
+                    precompute(g1_lagrange_brp, &x_ext_fft_columns)
+                        .ok()
+                        .flatten()
+                        .map(Arc::new)
                 }
             },
+            x_ext_fft_columns,
             cell_size,
         })
     }
@@ -293,8 +296,8 @@ impl KZGSettings<FsFr, FsG1, FsG2, FsFFTSettings, FsPoly, FsFp, FsG1Affine> for 
         self.precomputation.as_ref().map(|v| v.as_ref())
     }
 
-    fn get_x_ext_fft_column(&self, index: usize) -> &[FsG1] {
-        &self.x_ext_fft_columns[index]
+    fn get_x_ext_fft_columns(&self) -> &[Vec<FsG1>] {
+        &self.x_ext_fft_columns
     }
 
     fn get_cell_size(&self) -> usize {

--- a/constantine/src/mixed_kzg/mixed_kzg_settings.rs
+++ b/constantine/src/mixed_kzg/mixed_kzg_settings.rs
@@ -384,14 +384,12 @@ impl KZGSettings<CtFr, CtG1, CtG2, CtFFTSettings, CtPoly, CtFp, CtG1Affine>
         }
     }
 
-    fn get_x_ext_fft_column(&self, index: usize) -> &[CtG1] {
+    fn get_x_ext_fft_columns(&self) -> &[Vec<CtG1>] {
         match self {
             MixedKzgSettings::Constantine(_) => {
                 panic!("Context not in generic format")
             }
-            MixedKzgSettings::Generic(generic_context) => {
-                generic_context.get_x_ext_fft_column(index)
-            }
+            MixedKzgSettings::Generic(generic_context) => generic_context.get_x_ext_fft_columns(),
         }
     }
 

--- a/constantine/src/types/g1.rs
+++ b/constantine/src/types/g1.rs
@@ -9,7 +9,10 @@ use kzg::eth::c_bindings::blst_p1;
 use kzg::msm::precompute::PrecomputationTable;
 use kzg::G1LinComb;
 
-use core::fmt::{Debug, Formatter};
+use core::{
+    fmt::{Debug, Formatter},
+    hash::Hash,
+};
 
 use crate::kzg_proofs::g1_linear_combination;
 use crate::types::fp::CtFp;
@@ -34,11 +37,21 @@ use constantine_sys::{
 #[derive(Clone, Copy, Default)]
 pub struct CtG1(pub bls12_381_g1_jac);
 
+impl Hash for CtG1 {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        self.0.x.limbs.hash(state);
+        self.0.y.limbs.hash(state);
+        self.0.z.limbs.hash(state);
+    }
+}
+
 impl PartialEq for CtG1 {
     fn eq(&self, other: &Self) -> bool {
         unsafe { constantine::ctt_bls12_381_g1_jac_is_eq(&self.0, &other.0) != 0 }
     }
 }
+
+impl Eq for CtG1 {}
 
 impl Debug for CtG1 {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {

--- a/constantine/src/types/kzg_settings.rs
+++ b/constantine/src/types/kzg_settings.rs
@@ -101,8 +101,11 @@ impl KZGSettings<CtFr, CtG1, CtG2, CtFFTSettings, CtPoly, CtFp, CtG1Affine> for 
             g1_values_lagrange_brp: g1_lagrange_brp.to_vec(),
             g2_values_monomial: g2_monomial.to_vec(),
             fs: fft_settings.clone(),
+            precomputation: precompute(g1_lagrange_brp, &x_ext_fft_columns)
+                .ok()
+                .flatten()
+                .map(Arc::new),
             x_ext_fft_columns,
-            precomputation: precompute(g1_lagrange_brp).ok().flatten().map(Arc::new),
             cell_size,
         })
     }
@@ -271,8 +274,8 @@ impl KZGSettings<CtFr, CtG1, CtG2, CtFFTSettings, CtPoly, CtFp, CtG1Affine> for 
         self.precomputation.as_ref().map(|v| v.as_ref())
     }
 
-    fn get_x_ext_fft_column(&self, index: usize) -> &[CtG1] {
-        &self.x_ext_fft_columns[index]
+    fn get_x_ext_fft_columns(&self) -> &[Vec<CtG1>] {
+        &self.x_ext_fft_columns
     }
 
     fn get_cell_size(&self) -> usize {

--- a/kzg-bench/src/benches/lincomb.rs
+++ b/kzg-bench/src/benches/lincomb.rs
@@ -44,7 +44,7 @@ pub fn bench_g1_lincomb<
         })
     });
 
-    let precomputation = precompute::<TFr, TG1, TG1Fp, TG1Affine>(&points).unwrap();
+    let precomputation = precompute::<TFr, TG1, TG1Fp, TG1Affine>(&points, &[]).unwrap();
 
     if precomputation.is_some() {
         let id = format!(

--- a/kzg-bench/src/tests/bls12_381.rs
+++ b/kzg-bench/src/tests/bls12_381.rs
@@ -277,7 +277,7 @@ pub fn g1_small_linear_combination<
 
     // // Precompute once, use to calculate all other results
     {
-        let precomputation = precompute(&points).unwrap();
+        let precomputation = precompute(&points, &[]).unwrap();
 
         if precomputation.is_some() {
             for i in 0..=len {
@@ -297,7 +297,7 @@ pub fn g1_small_linear_combination<
     // Precompute for each set of points
     {
         for i in 0..=len {
-            let precomputation = precompute(&points[0..i]).unwrap();
+            let precomputation = precompute(&points[0..i], &[]).unwrap();
             if precomputation.is_some() {
                 let mut res = TG1::rand();
                 g1_linear_combination(

--- a/kzg/Cargo.toml
+++ b/kzg/Cargo.toml
@@ -9,6 +9,7 @@ num_cpus = { version = "1.16.0", optional = true }
 rayon = { version = "1.8.0", optional = true } 
 threadpool = { version = "^1.8.1", optional = true }
 siphasher = { version = "1.0.0", default-features = false }
+hashbrown = "0.15.2"
 
 [features]
 default = [

--- a/kzg/src/das.rs
+++ b/kzg/src/das.rs
@@ -560,7 +560,6 @@ fn compute_fk20_proofs<B: EcBackend>(
     let k2 = k * 2;
 
     let mut coeffs = vec![vec![B::Fr::default(); k]; k2];
-    let mut h_ext_fft = vec![B::G1::identity(); k2];
     let mut toeplitz_coeffs = vec![B::Fr::default(); k2];
     let mut toeplitz_coeffs_fft = vec![B::Fr::default(); k2];
 
@@ -572,14 +571,11 @@ fn compute_fk20_proofs<B: EcBackend>(
         }
     }
 
-    for i in 0..k2 {
-        h_ext_fft[i] = B::G1::g1_lincomb(
-            kzg_settings.get_x_ext_fft_column(i),
-            &coeffs[i],
-            cell_size,
-            None,
-        );
-    }
+    let h_ext_fft = B::G1::g1_lincomb_batch(
+        kzg_settings.get_x_ext_fft_columns(),
+        &coeffs,
+        kzg_settings.get_precomputation(),
+    )?;
 
     let mut h = fft_settings.fft_g1(&h_ext_fft, true)?;
 

--- a/kzg/src/msm/precompute.rs
+++ b/kzg/src/msm/precompute.rs
@@ -1,6 +1,6 @@
 extern crate alloc;
 
-use alloc::string::String;
+use alloc::{string::String, vec::Vec};
 
 use crate::{Fr, G1Affine, G1Fp, G1GetFp, G1Mul, G1};
 
@@ -42,8 +42,12 @@ where
     TG1Fp: G1Fp,
     TG1Affine: G1Affine<TG1, TG1Fp>,
 {
-    fn new(_: &[TG1]) -> Result<Option<Self>, String> {
+    fn new(_: &[TG1], _: &[Vec<TG1>]) -> Result<Option<Self>, String> {
         Ok(None)
+    }
+
+    pub fn multiply_batch(&self, _: &[Vec<TFr>]) -> Vec<TG1> {
+        panic!("This function must not be called")
     }
 
     pub fn multiply_sequential(&self, _: &[TFr]) -> TG1 {
@@ -61,6 +65,7 @@ pub type PrecomputationTable<TFr, TG1, TG1Fp, TG1Affine> = EmptyTable<TFr, TG1, 
 
 pub fn precompute<TFr, TG1, TG1Fp, TG1Affine>(
     points: &[TG1],
+    matrix: &[Vec<TG1>],
 ) -> Result<Option<PrecomputationTable<TFr, TG1, TG1Fp, TG1Affine>>, String>
 where
     TFr: Fr,
@@ -68,5 +73,5 @@ where
     TG1Fp: G1Fp,
     TG1Affine: G1Affine<TG1, TG1Fp>,
 {
-    PrecomputationTable::<TFr, TG1, TG1Fp, TG1Affine>::new(points)
+    PrecomputationTable::<TFr, TG1, TG1Fp, TG1Affine>::new(points, matrix)
 }

--- a/kzg/src/msm/sppark.rs
+++ b/kzg/src/msm/sppark.rs
@@ -44,9 +44,13 @@ where
     TG1Fp: G1Fp,
     TG1Affine: G1Affine<TG1, TG1Fp>,
 {
-    pub fn new(_: &[TG1]) -> Result<Option<Self>, String> {
+    pub fn new(_: &[TG1], _: &[Vec<TG1>]) -> Result<Option<Self>, String> {
         // TODO: currently no trait-based implementation for sppark msm, maybe in future
         Ok(None)
+    }
+
+    pub fn multiply_batch(&self, _: &[Vec<TFr>]) -> Vec<TG1> {
+        panic!("This function must not be called")
     }
 
     pub fn multiply_sequential(&self, _: &[TFr]) -> TG1 {

--- a/mcl/src/types/g1.rs
+++ b/mcl/src/types/g1.rs
@@ -1,5 +1,6 @@
 extern crate alloc;
 
+use core::hash::Hash;
 use core::ops::Add;
 use core::ops::Sub;
 
@@ -31,6 +32,14 @@ use super::fp::MclFp;
 #[repr(C)]
 #[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
 pub struct MclG1(pub mcl_g1);
+
+impl Hash for MclG1 {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        self.0.x.d.hash(state);
+        self.0.y.d.hash(state);
+        self.0.z.d.hash(state);
+    }
+}
 
 impl MclG1 {
     pub(crate) const fn from_xyz(x: mcl_fp, y: mcl_fp, z: mcl_fp) -> Self {

--- a/mcl/src/types/kzg_settings.rs
+++ b/mcl/src/types/kzg_settings.rs
@@ -103,8 +103,13 @@ impl KZGSettings<MclFr, MclG1, MclG2, MclFFTSettings, MclPoly, MclFp, MclG1Affin
             g1_values_lagrange_brp: g1_lagrange_brp.to_vec(),
             g2_values_monomial: g2_monomial.to_vec(),
             fs: fft_settings.clone(),
+            precomputation: {
+                precompute(g1_lagrange_brp, &x_ext_fft_columns)
+                    .ok()
+                    .flatten()
+                    .map(Arc::new)
+            },
             x_ext_fft_columns,
-            precomputation: { precompute(g1_lagrange_brp).ok().flatten().map(Arc::new) },
             cell_size,
         })
     }
@@ -274,8 +279,8 @@ impl KZGSettings<MclFr, MclG1, MclG2, MclFFTSettings, MclPoly, MclFp, MclG1Affin
         self.precomputation.as_ref().map(|v| v.as_ref())
     }
 
-    fn get_x_ext_fft_column(&self, index: usize) -> &[MclG1] {
-        &self.x_ext_fft_columns[index]
+    fn get_x_ext_fft_columns(&self) -> &[Vec<MclG1>] {
+        &self.x_ext_fft_columns
     }
 
     fn get_cell_size(&self) -> usize {

--- a/run-c-kzg-4844-benches.sh
+++ b/run-c-kzg-4844-benches.sh
@@ -65,13 +65,20 @@ cargo bench
 
 ###################### go benchmarks ######################
 
-print_msg "Patching go binding"
-git apply < ../go.patch
-cd bindings/go || exit
+if [ "$backend" != "constantine" ]; then
+  print_msg "Patching go binding"
+  git apply < ../go.patch
+  cd bindings/go || exit
 
-print_msg "Running go benchmarks"
-CGO_CFLAGS="-O2 -D__BLST_PORTABLE__" go test -run ^$ -bench .
-cd ../../..
+  print_msg "Running go benchmarks"
+  CGO_CFLAGS="-O2 -D__BLST_PORTABLE__" go test -run ^$ -bench .
+  cd ../..
+else
+  # TODO: fix this, constantine was working through go bindings previously
+  print_msg "Currently, go bindings are not supported for constantine backend"
+fi
+
+cd ..
 
 ###################### cleaning up ######################
 

--- a/zkcrypto/src/kzg_types.rs
+++ b/zkcrypto/src/kzg_types.rs
@@ -927,8 +927,11 @@ impl KZGSettings<ZFr, ZG1, ZG2, ZFFTSettings, PolyData, ZFp, ZG1Affine> for ZKZG
             g1_values_lagrange_brp: g1_lagrange_brp.to_vec(),
             g2_values_monomial: g2_monomial.to_vec(),
             fs: fft_settings.clone(),
+            precomputation: precompute(g1_lagrange_brp, &x_ext_fft_columns)
+                .ok()
+                .flatten()
+                .map(Arc::new),
             x_ext_fft_columns,
-            precomputation: precompute(g1_lagrange_brp).ok().flatten().map(Arc::new),
             cell_size,
         })
     }
@@ -1087,8 +1090,8 @@ impl KZGSettings<ZFr, ZG1, ZG2, ZFFTSettings, PolyData, ZFp, ZG1Affine> for ZKZG
         &self.g2_values_monomial
     }
 
-    fn get_x_ext_fft_column(&self, index: usize) -> &[ZG1] {
-        &self.x_ext_fft_columns[index]
+    fn get_x_ext_fft_columns(&self) -> &[Vec<ZG1>] {
+        &self.x_ext_fft_columns
     }
 
     fn get_cell_size(&self) -> usize {

--- a/zkcrypto/src/kzg_types.rs
+++ b/zkcrypto/src/kzg_types.rs
@@ -23,6 +23,7 @@ use kzg::{
     FFTFr, FFTSettings, Fr as KzgFr, G1Fp, G1GetFp, G1LinComb, G1Mul, G1ProjAddAffine, G2Mul,
     KZGSettings, PairingVerify, Poly, Scalar256, G1, G2,
 };
+use std::hash::Hash;
 use std::ops::{Add, AddAssign, Mul, MulAssign, Sub, SubAssign};
 use std::sync::Arc;
 
@@ -363,6 +364,14 @@ impl G1Fp for ZFp {
 #[derive(Debug, Default, PartialEq, Eq, Clone, Copy)]
 pub struct ZG1 {
     pub proj: G1Projective,
+}
+
+impl Hash for ZG1 {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.proj.x.0.hash(state);
+        self.proj.y.0.hash(state);
+        self.proj.z.0.hash(state);
+    }
 }
 
 impl ZG1 {


### PR DESCRIPTION
In this PR, several optimizations are ported from [`rust-eth-kzg`](https://github.com/crate-crypto/rust-eth-kzg):
1. Batch multiplication precomputation - doing precomputations after loading trusted setup
2. Using HashMap for deduplicate_commitments
3. Using HashSet to find missing cell indices in cell recovery
4. Batch inverse

Parallel benchmark times, with avg. CPU load:

|                                              |  rust-kzg | avg load |
| -------------------------------------------- | --------: | -------: |
| compute_cells_and_kzg_proofs                 | 48.513 ms |  27%-30% |
| recover_cells_and_kzg_proofs (50% missing)   | 59.624 ms |   25-30% |
| recover_cells_and_kzg_proofs (25% missing)   | 61.589 ms |   25-30% |
| recover_cells_and_kzg_proofs (12.5% missing) | 57.518 ms |   25-30% |
| recover_cells_and_kzg_proofs (1 missing)     | 55.628 ms |   25-30% |
| recover_cells_and_kzg_proofs (2 missing)     | 56.000 ms |   25-30% |
| recover_cells_and_kzg_proofs (3 missing)     | 55.269 ms |   25-30% |
| recover_cells_and_kzg_proofs (4 missing)     | 54.523 ms |   25-30% |
| recover_cells_and_kzg_proofs (5 missing)     | 57.823 ms |   25-30% |
| verify_cell_kzg_proof_batch                  | 148.35 ms |   37-40% |
| verify_cell_kzg_proof_batch (rows)/1         | 9.1205 ms |   18-20% |
| verify_cell_kzg_proof_batch (rows)/2         | 12.693 ms |   20-22% |
| verify_cell_kzg_proof_batch (rows)/4         | 16.208 ms |   23-24% |
| verify_cell_kzg_proof_batch (rows)/8         | 24.932 ms |   27-30% |
| verify_cell_kzg_proof_batch (rows)/16        | 41.965 ms |   30-33% |
| verify_cell_kzg_proof_batch (rows)/32        | 76.117 ms |   30-33% |
| verify_cell_kzg_proof_batch (rows)/64        | 147.48 ms |      34% |
| verify_cell_kzg_proof_batch (columns)/1      | 9.0926 ms |   20-22% |
| verify_cell_kzg_proof_batch (columns)/2      | 9.8894 ms |   22-24% |
| verify_cell_kzg_proof_batch (columns)/4      | 12.491 ms |   26-27% |
| verify_cell_kzg_proof_batch (columns)/8      | 16.998 ms |   27-28% |
| verify_cell_kzg_proof_batch (columns)/16     | 27.090 ms |   28-30% |
| verify_cell_kzg_proof_batch (columns)/32     | 42.328 ms |   29-30% |
| verify_cell_kzg_proof_batch (columns)/64     | 75.353 ms |   32-34% |
| verify_cell_kzg_proof_batch (columns)/128    | 153.58 ms |   38-40% |