### PR TITLE
Fix parallel bgmw small msm

### DIFF
--- a/arkworks3/tests/bls12_381.rs
+++ b/arkworks3/tests/bls12_381.rs
@@ -103,6 +103,11 @@ mod tests {
     }
 
     #[test]
+    fn g1_small_linear_combination_() {
+        g1_small_linear_combination::<ArkFr, ArkG1, ArkFp, ArkG1Affine>(&g1_linear_combination)
+    }
+
+    #[test]
     pub fn pairings_work_() {
         pairings_work::<ArkFr, ArkG1, ArkG2>(&pairings_verify);
     }

--- a/arkworks4/tests/bls12_381.rs
+++ b/arkworks4/tests/bls12_381.rs
@@ -103,6 +103,11 @@ mod tests {
     }
 
     #[test]
+    fn g1_small_linear_combination_() {
+        g1_small_linear_combination::<ArkFr, ArkG1, ArkFp, ArkG1Affine>(&g1_linear_combination)
+    }
+
+    #[test]
     pub fn pairings_work_() {
         pairings_work::<ArkFr, ArkG1, ArkG2>(&pairings_verify);
     }

--- a/arkworks5/tests/bls12_381.rs
+++ b/arkworks5/tests/bls12_381.rs
@@ -103,6 +103,11 @@ mod tests {
     }
 
     #[test]
+    fn g1_small_linear_combination_() {
+        g1_small_linear_combination::<ArkFr, ArkG1, ArkFp, ArkG1Affine>(&g1_linear_combination)
+    }
+
+    #[test]
     pub fn pairings_work_() {
         pairings_work::<ArkFr, ArkG1, ArkG2>(&pairings_verify);
     }

--- a/blst/tests/bls12_381.rs
+++ b/blst/tests/bls12_381.rs
@@ -5,8 +5,8 @@ mod tests {
         fr_div_by_zero, fr_div_works, fr_equal_works, fr_from_uint64_works, fr_is_null_works,
         fr_is_one_works, fr_is_zero_works, fr_negate_works, fr_pow_works, fr_uint64s_roundtrip,
         g1_identity_is_identity, g1_identity_is_infinity, g1_make_linear_combination,
-        g1_random_linear_combination, log_2_byte_works, p1_mul_works, p1_sub_works,
-        p2_add_or_dbl_works, p2_mul_works, p2_sub_works, pairings_work,
+        g1_random_linear_combination, g1_small_linear_combination, log_2_byte_works, p1_mul_works,
+        p1_sub_works, p2_add_or_dbl_works, p2_mul_works, p2_sub_works, pairings_work,
     };
 
     use rust_kzg_blst::kzg_proofs::{g1_linear_combination, pairings_verify};
@@ -113,6 +113,11 @@ mod tests {
     #[test]
     fn g1_random_linear_combination_() {
         g1_random_linear_combination::<FsFr, FsG1, FsFp, FsG1Affine>(&g1_linear_combination)
+    }
+
+    #[test]
+    fn g1_small_linear_combination_() {
+        g1_small_linear_combination::<FsFr, FsG1, FsFp, FsG1Affine>(&g1_linear_combination)
     }
 
     #[test]

--- a/constantine/tests/bls12_381.rs
+++ b/constantine/tests/bls12_381.rs
@@ -5,8 +5,8 @@ mod tests {
         fr_div_by_zero, fr_div_works, fr_equal_works, fr_from_uint64_works, fr_is_null_works,
         fr_is_one_works, fr_is_zero_works, fr_negate_works, fr_pow_works, fr_uint64s_roundtrip,
         g1_identity_is_identity, g1_identity_is_infinity, g1_make_linear_combination,
-        g1_random_linear_combination, log_2_byte_works, p1_mul_works, p1_sub_works,
-        p2_add_or_dbl_works, p2_mul_works, p2_sub_works, pairings_work,
+        g1_random_linear_combination, g1_small_linear_combination, log_2_byte_works, p1_mul_works,
+        p1_sub_works, p2_add_or_dbl_works, p2_mul_works, p2_sub_works, pairings_work,
     };
 
     use rust_kzg_constantine::kzg_proofs::{g1_linear_combination, pairings_verify};
@@ -113,6 +113,11 @@ mod tests {
     #[test]
     fn g1_random_linear_combination_() {
         g1_random_linear_combination::<CtFr, CtG1, CtFp, CtG1Affine>(&g1_linear_combination)
+    }
+
+    #[test]
+    fn g1_small_linear_combination_() {
+        g1_small_linear_combination::<CtFr, CtG1, CtFp, CtG1Affine>(&g1_linear_combination)
     }
 
     #[test]

--- a/kzg/src/msm/bgmw.rs
+++ b/kzg/src/msm/bgmw.rs
@@ -281,8 +281,8 @@ impl<
         let scalars = scalars.iter().map(TFr::to_scalar).collect::<Vec<_>>();
         let scalars = &scalars[..];
 
-        // |grid[]| holds "coordinates" and place for result
-        let mut grid: Vec<(Tile, Cell<TG1>)> = Vec::with_capacity(nx * ny);
+        // |grid[]| holds "coordinates"
+        let mut grid: Vec<Tile> = Vec::with_capacity(nx * ny);
         #[allow(clippy::uninit_vec)]
         unsafe {
             grid.set_len(grid.capacity())
@@ -292,20 +292,20 @@ impl<
         let mut total = 0usize;
 
         while total < nx {
-            grid[total].0.x = total * dx;
-            grid[total].0.dx = dx;
-            grid[total].0.y = y;
-            grid[total].0.dy = 255 - y;
+            grid[total].x = total * dx;
+            grid[total].dx = dx;
+            grid[total].y = y;
+            grid[total].dy = NBITS - y;
             total += 1;
         }
-        grid[total - 1].0.dx = npoints - grid[total - 1].0.x;
+        grid[total - 1].dx = npoints - grid[total - 1].x;
         while y != 0 {
             y -= window;
             for i in 0..nx {
-                grid[total].0.x = grid[i].0.x;
-                grid[total].0.dx = grid[i].0.dx;
-                grid[total].0.y = y;
-                grid[total].0.dy = window;
+                grid[total].x = grid[i].x;
+                grid[total].dx = grid[i].dx;
+                grid[total].y = y;
+                grid[total].dy = window;
                 total += 1;
             }
         }
@@ -345,9 +345,9 @@ impl<
                         break;
                     }
 
-                    let x = grid[work].0.x;
-                    let y = grid[work].0.y;
-                    let dx = grid[work].0.dx;
+                    let x = grid[work].x;
+                    let y = grid[work].y;
+                    let dx = grid[work].dx;
 
                     let row_start = (y / window) * self.numpoints + x;
                     let points = &self.points[row_start..(row_start + dx)];
@@ -364,7 +364,7 @@ impl<
             });
         }
 
-        let mut ret = <TG1>::default();
+        let mut ret = TG1::zero();
         for _ in 0..n_workers {
             let idx = rx.recv().unwrap();
 

--- a/kzg/src/msm/bgmw.rs
+++ b/kzg/src/msm/bgmw.rs
@@ -394,6 +394,10 @@ pub fn p1_tile_bgmw<TG1: G1 + G1GetFp<TFp>, TFp: G1Fp, TG1Affine: G1Affine<TG1, 
     wbits: usize,
     cbits: usize,
 ) {
+    if scalars.is_empty() {
+        return;
+    }
+
     // Get first scalar
     let scalar = &scalars[0];
 
@@ -419,6 +423,11 @@ pub fn p1_tile_bgmw<TG1: G1 + G1GetFp<TFp>, TFp: G1Fp, TG1Affine: G1Affine<TG1, 
     // Calculate first window value (encoded bucket index)
     let wval = (get_wval_limb(scalar, bit0, wbits) << z) & wmask;
     let mut wval = booth_encode(wval, cbits);
+
+    if scalars.len() == 1 {
+        booth_decode(buckets, wval, cbits, point);
+        return;
+    }
 
     // Get second scalar
     let scalar = &scalars[1];

--- a/kzg/src/msm/bgmw.rs
+++ b/kzg/src/msm/bgmw.rs
@@ -252,6 +252,7 @@ impl<
         use super::{
             cell::Cell,
             thread_pool::{da_pool, ThreadPoolExt},
+            tiling_pippenger_ops::tiling_pippenger,
         };
         use core::sync::atomic::{AtomicUsize, Ordering};
         use std::sync::{mpsc, Arc};
@@ -259,6 +260,11 @@ impl<
         let npoints = scalars.len();
         let pool = da_pool();
         let ncpus = pool.max_count();
+
+        if ncpus > npoints || npoints < 32 {
+            let scalars = scalars.iter().map(TFr::to_scalar).collect::<Vec<_>>();
+            return tiling_pippenger(&self.points[0..npoints], &scalars);
+        }
 
         struct Tile {
             x: usize,

--- a/kzg/src/msm/bgmw.rs
+++ b/kzg/src/msm/bgmw.rs
@@ -152,7 +152,11 @@ const fn bgmw_parallel_window_size(npoints: usize, ncpus: usize) -> (usize, usiz
         mult += 1;
     }
 
-    (opt_x, 255usize.div_ceil(opt), opt)
+    (
+        opt_x,
+        255usize.div_ceil(opt) + is_zero((NBITS % opt) as u64) as usize,
+        opt,
+    )
 }
 
 impl<

--- a/kzg/src/msm/msm_impls.rs
+++ b/kzg/src/msm/msm_impls.rs
@@ -91,7 +91,7 @@ pub fn msm<
     precomputation: Option<&PrecomputationTable<TFr, TG1, TG1Fp, TG1Affine>>,
 ) -> TG1 {
     if len < 8 {
-        let mut out = TG1::default();
+        let mut out = TG1::zero();
         for i in 0..len {
             let tmp = points[i].mul(&scalars[i]);
             out.add_or_dbl_assign(&tmp);

--- a/kzg/src/msm/tiling_pippenger_ops.rs
+++ b/kzg/src/msm/tiling_pippenger_ops.rs
@@ -142,9 +142,9 @@ pub fn tiling_pippenger<TG1: G1 + G1GetFp<TG1Fp>, TG1Fp: G1Fp, TG1Affine: G1Affi
     let mut wbits: usize = 255 % window;
     let mut cbits: usize = wbits + 1;
     let mut bit0: usize = 255;
-    let mut tile = TG1::default();
+    let mut tile = TG1::zero();
 
-    let mut ret = TG1::default();
+    let mut ret = TG1::zero();
 
     loop {
         bit0 -= wbits;

--- a/mcl/tests/bls12_381.rs
+++ b/mcl/tests/bls12_381.rs
@@ -5,8 +5,8 @@ mod tests {
         fr_div_by_zero, fr_div_works, fr_equal_works, fr_from_uint64_works, fr_is_null_works,
         fr_is_one_works, fr_is_zero_works, fr_negate_works, fr_pow_works, fr_uint64s_roundtrip,
         g1_identity_is_identity, g1_identity_is_infinity, g1_make_linear_combination,
-        g1_random_linear_combination, log_2_byte_works, p1_mul_works, p1_sub_works,
-        p2_add_or_dbl_works, p2_mul_works, p2_sub_works, pairings_work,
+        g1_random_linear_combination, g1_small_linear_combination, log_2_byte_works, p1_mul_works,
+        p1_sub_works, p2_add_or_dbl_works, p2_mul_works, p2_sub_works, pairings_work,
     };
 
     use rust_kzg_mcl::kzg_proofs::{g1_linear_combination, pairings_verify};
@@ -113,6 +113,11 @@ mod tests {
     #[test]
     fn g1_random_linear_combination_() {
         g1_random_linear_combination::<MclFr, MclG1, MclFp, MclG1Affine>(&g1_linear_combination)
+    }
+
+    #[test]
+    fn g1_small_linear_combination_() {
+        g1_small_linear_combination::<MclFr, MclG1, MclFp, MclG1Affine>(&g1_linear_combination)
     }
 
     #[test]


### PR DESCRIPTION
This PR fixes #296.

* Fixed out of bound access when computing bgmw tile
* Fixed issue with paralell msm, when scalar width is divisible by window size (e.g. 5, 15, 17)