### PR TITLE
Fix rust poly API

### DIFF
--- a/arkworks3/src/kzg_proofs.rs
+++ b/arkworks3/src/kzg_proofs.rs
@@ -9,10 +9,11 @@ use ark_ec::PairingEngine;
 use ark_ec::ProjectiveCurve;
 use ark_poly::Polynomial;
 use ark_std::One;
+use kzg::common_utils::log2_pow2;
 use kzg::eip_4844::hash_to_bls_field;
 use kzg::eth::c_bindings::CKZGSettings;
 use kzg::msm::precompute::PrecomputationTable;
-use kzg::{eth, Fr, G1Mul, G2Mul, G1, G2};
+use kzg::{eth, FFTSettings as _, Fr, G1Mul, G2Mul, FFTG1, G1, G2};
 use std::ops::Neg;
 
 #[derive(Debug, Clone)]
@@ -114,19 +115,20 @@ pub fn generate_trusted_setup(
     let s = hash_to_bls_field(&secret);
     let mut s_pow = Fr::one();
 
-    let mut s1 = Vec::with_capacity(n);
-    let mut s2 = Vec::with_capacity(n);
-    let mut s3 = Vec::with_capacity(n);
+    let mut g1_monomial_values = Vec::with_capacity(n);
+    let mut g2_monomial_values = Vec::with_capacity(n);
 
     for _ in 0..n {
-        s1.push(ArkG1::generator().mul(&s_pow));
-        s2.push(ArkG1::generator().mul(&s_pow)); // TODO: this should be lagrange form
-        s3.push(ArkG2::generator().mul(&s_pow));
+        g1_monomial_values.push(ArkG1::generator().mul(&s_pow));
+        g2_monomial_values.push(ArkG2::generator().mul(&s_pow));
 
         s_pow = s_pow.mul(&s);
     }
 
-    (s1, s2, s3)
+    let s = FFTSettings::new(log2_pow2(n)).unwrap();
+    let g1_lagrange_values = s.fft_g1(&g1_monomial_values, true).unwrap();
+
+    (g1_monomial_values, g1_lagrange_values, g2_monomial_values)
 }
 
 pub fn eval_poly(p: &PolyData, x: &ArkFr) -> ArkFr {

--- a/arkworks3/src/kzg_types.rs
+++ b/arkworks3/src/kzg_types.rs
@@ -996,17 +996,17 @@ impl KZGSettings<ArkFr, ArkG1, ArkG2, LFFTSettings, PolyData, ArkFp, ArkG1Affine
     }
 
     fn commit_to_poly(&self, p: &PolyData) -> Result<ArkG1, String> {
-        if p.coeffs.len() > self.g1_values_lagrange_brp.len() {
+        if p.coeffs.len() > self.g1_values_monomial.len() {
             return Err(String::from("Polynomial is longer than secret g1"));
         }
 
         let mut out = ArkG1::default();
         g1_linear_combination(
             &mut out,
-            &self.g1_values_lagrange_brp,
+            &self.g1_values_monomial,
             &p.coeffs,
             p.coeffs.len(),
-            self.get_precomputation(),
+            None,
         );
 
         Ok(out)

--- a/arkworks3/tests/kzg_proofs.rs
+++ b/arkworks3/tests/kzg_proofs.rs
@@ -2,9 +2,15 @@
 mod tests {
     use kzg_bench::tests::kzg_proofs::{
         commit_to_nil_poly, commit_to_too_long_poly_returns_err, proof_multi, proof_single,
+        trusted_setup_in_correct_form,
     };
     use rust_kzg_arkworks3::eip_7594::ArkBackend;
     use rust_kzg_arkworks3::kzg_proofs::generate_trusted_setup;
+
+    #[test]
+    pub fn test_trusted_setup_in_correct_form() {
+        trusted_setup_in_correct_form::<ArkBackend>(&generate_trusted_setup);
+    }
 
     #[test]
     fn proof_single_() {

--- a/arkworks4/src/fk20_proofs.rs
+++ b/arkworks4/src/fk20_proofs.rs
@@ -45,7 +45,7 @@ impl
 
         let mut x = Vec::new();
         for i in 0..(n - 1) {
-            x.push(ks.g1_values_lagrange_brp[n - 2 - i])
+            x.push(ks.g1_values_monomial[n - 2 - i])
         }
         x.push(G1_IDENTITY);
 
@@ -123,7 +123,7 @@ impl FK20MultiSettings<BlstFr, ArkG1, ArkG2, FFTSettings, PolyData, KZGSettings,
             };
             let mut j = start;
             for i in x.iter_mut().take(k - 1) {
-                i.0 = ks.g1_values_lagrange_brp[j].0;
+                i.0 = ks.g1_values_monomial[j].0;
                 if j >= chunk_len {
                     j -= chunk_len;
                 } else {

--- a/arkworks4/src/kzg_types.rs
+++ b/arkworks4/src/kzg_types.rs
@@ -704,17 +704,17 @@ impl KZGSettings<ArkFr, ArkG1, ArkG2, LFFTSettings, PolyData, ArkFp, ArkG1Affine
     }
 
     fn commit_to_poly(&self, p: &PolyData) -> Result<ArkG1, String> {
-        if p.coeffs.len() > self.g1_values_lagrange_brp.len() {
+        if p.coeffs.len() > self.g1_values_monomial.len() {
             return Err(String::from("Polynomial is longer than secret g1"));
         }
 
         let mut out = ArkG1::default();
         g1_linear_combination(
             &mut out,
-            &self.g1_values_lagrange_brp,
+            &self.g1_values_monomial,
             &p.coeffs,
             p.coeffs.len(),
-            self.get_precomputation(),
+            None,
         );
 
         Ok(out)

--- a/arkworks4/tests/kzg_proofs.rs
+++ b/arkworks4/tests/kzg_proofs.rs
@@ -2,9 +2,15 @@
 mod tests {
     use kzg_bench::tests::kzg_proofs::{
         commit_to_nil_poly, commit_to_too_long_poly_returns_err, proof_multi, proof_single,
+        trusted_setup_in_correct_form,
     };
     use rust_kzg_arkworks4::eip_7594::ArkBackend;
     use rust_kzg_arkworks4::kzg_proofs::generate_trusted_setup;
+
+    #[test]
+    pub fn test_trusted_setup_in_correct_form() {
+        trusted_setup_in_correct_form::<ArkBackend>(&generate_trusted_setup);
+    }
 
     #[test]
     fn proof_single_() {

--- a/arkworks5/src/fk20_proofs.rs
+++ b/arkworks5/src/fk20_proofs.rs
@@ -45,7 +45,7 @@ impl
 
         let mut x = Vec::new();
         for i in 0..(n - 1) {
-            x.push(ks.g1_values_lagrange_brp[n - 2 - i])
+            x.push(ks.g1_values_monomial[n - 2 - i])
         }
         x.push(G1_IDENTITY);
 
@@ -123,7 +123,7 @@ impl FK20MultiSettings<BlstFr, ArkG1, ArkG2, FFTSettings, PolyData, KZGSettings,
             };
             let mut j = start;
             for i in x.iter_mut().take(k - 1) {
-                i.0 = ks.g1_values_lagrange_brp[j].0;
+                i.0 = ks.g1_values_monomial[j].0;
                 if j >= chunk_len {
                     j -= chunk_len;
                 } else {

--- a/arkworks5/src/kzg_types.rs
+++ b/arkworks5/src/kzg_types.rs
@@ -704,17 +704,17 @@ impl KZGSettings<ArkFr, ArkG1, ArkG2, LFFTSettings, PolyData, ArkFp, ArkG1Affine
     }
 
     fn commit_to_poly(&self, p: &PolyData) -> Result<ArkG1, String> {
-        if p.coeffs.len() > self.g1_values_lagrange_brp.len() {
+        if p.coeffs.len() > self.g1_values_monomial.len() {
             return Err(String::from("Polynomial is longer than secret g1"));
         }
 
         let mut out = ArkG1::default();
         g1_linear_combination(
             &mut out,
-            &self.g1_values_lagrange_brp,
+            &self.g1_values_monomial,
             &p.coeffs,
             p.coeffs.len(),
-            self.get_precomputation(),
+            None,
         );
 
         Ok(out)

--- a/arkworks5/tests/kzg_proofs.rs
+++ b/arkworks5/tests/kzg_proofs.rs
@@ -2,9 +2,15 @@
 mod tests {
     use kzg_bench::tests::kzg_proofs::{
         commit_to_nil_poly, commit_to_too_long_poly_returns_err, proof_multi, proof_single,
+        trusted_setup_in_correct_form,
     };
     use rust_kzg_arkworks5::eip_7594::ArkBackend;
     use rust_kzg_arkworks5::kzg_proofs::generate_trusted_setup;
+
+    #[test]
+    pub fn test_trusted_setup_in_correct_form() {
+        trusted_setup_in_correct_form::<ArkBackend>(&generate_trusted_setup);
+    }
 
     #[test]
     fn proof_single_() {

--- a/blst/src/types/fk20_multi_settings.rs
+++ b/blst/src/types/fk20_multi_settings.rs
@@ -78,7 +78,7 @@ impl FK20MultiSettings<FsFr, FsG1, FsG2, FsFFTSettings, FsPoly, FsKZGSettings, F
                 let mut j = start;
 
                 while i + 1 < k {
-                    x.push(ks.g1_values_lagrange_brp[j]);
+                    x.push(ks.g1_values_monomial[j]);
 
                     i += 1;
 

--- a/blst/src/types/fk20_single_settings.rs
+++ b/blst/src/types/fk20_single_settings.rs
@@ -40,7 +40,7 @@ impl FK20SingleSettings<FsFr, FsG1, FsG2, FsFFTSettings, FsPoly, FsKZGSettings, 
 
         let mut x = Vec::with_capacity(n);
         for i in 0..n - 1 {
-            x.push(kzg_settings.g1_values_lagrange_brp[n - 2 - i]);
+            x.push(kzg_settings.g1_values_monomial[n - 2 - i]);
         }
         x.push(FsG1::identity());
 

--- a/blst/src/types/kzg_settings.rs
+++ b/blst/src/types/kzg_settings.rs
@@ -129,17 +129,17 @@ impl KZGSettings<FsFr, FsG1, FsG2, FsFFTSettings, FsPoly, FsFp, FsG1Affine> for 
     }
 
     fn commit_to_poly(&self, poly: &FsPoly) -> Result<FsG1, String> {
-        if poly.coeffs.len() > self.g1_values_lagrange_brp.len() {
+        if poly.coeffs.len() > self.g1_values_monomial.len() {
             return Err(String::from("Polynomial is longer than secret g1"));
         }
 
         let mut out = FsG1::default();
         g1_linear_combination(
             &mut out,
-            &self.g1_values_lagrange_brp,
+            &self.g1_values_monomial,
             &poly.coeffs,
             poly.coeffs.len(),
-            self.get_precomputation(),
+            None,
         );
 
         Ok(out)

--- a/blst/tests/kzg_proofs.rs
+++ b/blst/tests/kzg_proofs.rs
@@ -7,12 +7,18 @@ mod tests {
     use kzg::G1;
     use kzg_bench::tests::kzg_proofs::{
         commit_to_nil_poly, commit_to_too_long_poly_returns_err, proof_multi, proof_single,
+        trusted_setup_in_correct_form,
     };
 
     use rust_kzg_blst::eip_7594::BlstBackend;
     use rust_kzg_blst::types::g1::FsG1;
     use rust_kzg_blst::types::g2::FsG2;
     use rust_kzg_blst::utils::generate_trusted_setup;
+
+    #[test]
+    pub fn test_trusted_setup_in_correct_form() {
+        trusted_setup_in_correct_form::<BlstBackend>(&generate_trusted_setup);
+    }
 
     #[test]
     pub fn test_proof_single() {

--- a/constantine/src/types/fk20_multi_settings.rs
+++ b/constantine/src/types/fk20_multi_settings.rs
@@ -78,7 +78,7 @@ impl FK20MultiSettings<CtFr, CtG1, CtG2, CtFFTSettings, CtPoly, CtKZGSettings, C
                 let mut j = start;
 
                 while i + 1 < k {
-                    x.push(ks.g1_values_lagrange_brp[j]);
+                    x.push(ks.g1_values_monomial[j]);
 
                     i += 1;
 

--- a/constantine/src/types/fk20_single_settings.rs
+++ b/constantine/src/types/fk20_single_settings.rs
@@ -40,7 +40,7 @@ impl FK20SingleSettings<CtFr, CtG1, CtG2, CtFFTSettings, CtPoly, CtKZGSettings, 
 
         let mut x = Vec::with_capacity(n);
         for i in 0..n - 1 {
-            x.push(kzg_settings.g1_values_lagrange_brp[n - 2 - i]);
+            x.push(kzg_settings.g1_values_monomial[n - 2 - i]);
         }
         x.push(CtG1::identity());
 

--- a/constantine/src/types/kzg_settings.rs
+++ b/constantine/src/types/kzg_settings.rs
@@ -108,17 +108,17 @@ impl KZGSettings<CtFr, CtG1, CtG2, CtFFTSettings, CtPoly, CtFp, CtG1Affine> for 
     }
 
     fn commit_to_poly(&self, poly: &CtPoly) -> Result<CtG1, String> {
-        if poly.coeffs.len() > self.g1_values_lagrange_brp.len() {
+        if poly.coeffs.len() > self.g1_values_monomial.len() {
             return Err(String::from("Polynomial is longer than secret g1"));
         }
 
         let mut out = CtG1::default();
         g1_linear_combination(
             &mut out,
-            &self.g1_values_lagrange_brp,
+            &self.g1_values_monomial,
             &poly.coeffs,
             poly.coeffs.len(),
-            self.get_precomputation(),
+            None,
         );
 
         Ok(out)

--- a/constantine/src/utils.rs
+++ b/constantine/src/utils.rs
@@ -2,11 +2,11 @@ extern crate alloc;
 
 use alloc::vec::Vec;
 
+use kzg::common_utils::log2_pow2;
 use kzg::eip_4844::{hash_to_bls_field, PrecomputationTableManager};
 use kzg::eth::c_bindings::CKZGSettings;
-use kzg::{eth, Fr, G1Mul, G2Mul};
+use kzg::{eth, FFTSettings, Fr, G1Mul, G2Mul, FFTG1, G1, G2};
 
-use crate::consts::{G1_GENERATOR, G2_GENERATOR};
 use crate::types::fft_settings::CtFFTSettings;
 use crate::types::fp::CtFp;
 use crate::types::fr::CtFr;
@@ -20,19 +20,20 @@ pub fn generate_trusted_setup(
     let s = hash_to_bls_field(&secret);
     let mut s_pow = Fr::one();
 
-    let mut s1 = Vec::with_capacity(n);
-    let mut s2 = Vec::with_capacity(n);
-    let mut s3 = Vec::with_capacity(n);
+    let mut g1_monomial_values = Vec::with_capacity(n);
+    let mut g2_monomial_values = Vec::with_capacity(n);
 
     for _ in 0..n {
-        s1.push(G1_GENERATOR.mul(&s_pow));
-        s2.push(G1_GENERATOR.mul(&s_pow)); // TODO: this should be lagrange form
-        s3.push(G2_GENERATOR.mul(&s_pow));
+        g1_monomial_values.push(CtG1::generator().mul(&s_pow));
+        g2_monomial_values.push(CtG2::generator().mul(&s_pow));
 
         s_pow = s_pow.mul(&s);
     }
 
-    (s1, s2, s3)
+    let s = CtFFTSettings::new(log2_pow2(n)).unwrap();
+    let g1_lagrange_values = s.fft_g1(&g1_monomial_values, true).unwrap();
+
+    (g1_monomial_values, g1_lagrange_values, g2_monomial_values)
 }
 
 pub fn ptr_transmute<T, U>(t: &T) -> *const U {

--- a/constantine/tests/kzg_proofs.rs
+++ b/constantine/tests/kzg_proofs.rs
@@ -3,9 +3,15 @@ mod tests {
 
     use kzg_bench::tests::kzg_proofs::{
         commit_to_nil_poly, commit_to_too_long_poly_returns_err, proof_multi, proof_single,
+        trusted_setup_in_correct_form,
     };
 
     use rust_kzg_constantine::{eip_7594::CtBackend, utils::generate_trusted_setup};
+
+    #[test]
+    pub fn test_trusted_setup_in_correct_form() {
+        trusted_setup_in_correct_form::<CtBackend>(&generate_trusted_setup);
+    }
 
     #[test]
     pub fn test_proof_single() {

--- a/kzg-bench/src/benches/fk20.rs
+++ b/kzg-bench/src/benches/fk20.rs
@@ -33,7 +33,7 @@ pub fn bench_fk_single_da<
     let coeffs: Vec<u64> = vec![rng.next_u64(); 1 << (BENCH_SCALE - 1)];
     let poly_len: usize = coeffs.len();
     let n_len: usize = 1 << BENCH_SCALE;
-    let secrets_len = n_len + 1;
+    let secrets_len = n_len;
 
     assert!(n_len >= 2 * poly_len);
     let mut p = B::Poly::new(poly_len);

--- a/kzg-bench/src/tests/fk20_proofs.rs
+++ b/kzg-bench/src/tests/fk20_proofs.rs
@@ -24,11 +24,11 @@ pub fn fk_single<
 >(
     generate_trusted_setup: &dyn Fn(usize, [u8; 32usize]) -> (Vec<B::G1>, Vec<B::G1>, Vec<B::G2>),
 ) {
-    let coeffs: Vec<u64> = vec![1, 2, 3, 4, 7, 7, 7, 7, 13, 13, 13, 13, 13, 13, 13, 13];
+    let coeffs = [1, 2, 3, 4, 7, 7, 7, 7, 13, 13, 13, 13, 13, 13, 13, 13];
     let poly_len: usize = coeffs.len();
     let n: usize = 5;
     let n_len: usize = 1 << n;
-    let secrets_len = n_len + 1;
+    let secrets_len = n_len;
 
     assert!(n_len >= 2 * poly_len);
     let mut p = B::Poly::new(poly_len);
@@ -87,12 +87,12 @@ pub fn fk_single_strided<
 >(
     generate_trusted_setup: &dyn Fn(usize, [u8; 32usize]) -> (Vec<B::G1>, Vec<B::G1>, Vec<B::G2>),
 ) {
-    let coeffs: Vec<u64> = vec![1, 2, 3, 4, 7, 7, 7, 7, 13, 13, 13, 13, 13, 13, 13, 13];
+    let coeffs = [1, 2, 3, 4, 7, 7, 7, 7, 13, 13, 13, 13, 13, 13, 13, 13];
     let poly_len: usize = coeffs.len();
     let n: usize = 8;
     let n_len: usize = 1 << n;
     let stride: usize = n_len / (2 * poly_len);
-    let secrets_len = n_len + 1;
+    let secrets_len = n_len;
 
     assert!(n_len >= 2 * poly_len);
     let mut p = B::Poly::new(poly_len);
@@ -138,7 +138,7 @@ pub fn fk_multi_settings<
     generate_trusted_setup: &dyn Fn(usize, [u8; 32usize]) -> (Vec<B::G1>, Vec<B::G1>, Vec<B::G2>),
 ) {
     let n: usize = 5;
-    let secrets_len: usize = 33;
+    let secrets_len: usize = 32;
 
     // Initialise the secrets and data structures
     let (s1, s2, s3) = generate_trusted_setup(secrets_len, SECRET);

--- a/mcl/src/types/fk20_multi_settings.rs
+++ b/mcl/src/types/fk20_multi_settings.rs
@@ -87,7 +87,7 @@ impl
                 let mut j = start;
 
                 while i + 1 < k {
-                    x.push(ks.g1_values_lagrange_brp[j]);
+                    x.push(ks.g1_values_monomial[j]);
 
                     i += 1;
 

--- a/mcl/src/types/fk20_single_settings.rs
+++ b/mcl/src/types/fk20_single_settings.rs
@@ -49,7 +49,7 @@ impl
 
         let mut x = Vec::with_capacity(n);
         for i in 0..n - 1 {
-            x.push(kzg_settings.g1_values_lagrange_brp[n - 2 - i]);
+            x.push(kzg_settings.g1_values_monomial[n - 2 - i]);
         }
         x.push(MclG1::identity());
 

--- a/mcl/src/types/kzg_settings.rs
+++ b/mcl/src/types/kzg_settings.rs
@@ -110,17 +110,17 @@ impl KZGSettings<MclFr, MclG1, MclG2, MclFFTSettings, MclPoly, MclFp, MclG1Affin
     }
 
     fn commit_to_poly(&self, poly: &MclPoly) -> Result<MclG1, String> {
-        if poly.coeffs.len() > self.g1_values_lagrange_brp.len() {
+        if poly.coeffs.len() > self.g1_values_monomial.len() {
             return Err(String::from("Polynomial is longer than secret g1"));
         }
 
         let mut out = MclG1::default();
         g1_linear_combination(
             &mut out,
-            &self.g1_values_lagrange_brp,
+            &self.g1_values_monomial,
             &poly.coeffs,
             poly.coeffs.len(),
-            self.get_precomputation(),
+            None,
         );
 
         Ok(out)

--- a/mcl/src/utils.rs
+++ b/mcl/src/utils.rs
@@ -2,10 +2,11 @@ extern crate alloc;
 
 use alloc::vec::Vec;
 
+use kzg::common_utils::log2_pow2;
 use kzg::eip_4844::{hash_to_bls_field, PrecomputationTableManager};
-use kzg::{Fr, G1Mul, G2Mul};
+use kzg::{FFTSettings, Fr, G1Mul, G2Mul, FFTG1, G1, G2};
 
-use crate::consts::{G1_GENERATOR, G2_GENERATOR};
+use crate::types::fft_settings::MclFFTSettings;
 use crate::types::fp::MclFp;
 use crate::types::fr::MclFr;
 use crate::types::g1::{MclG1, MclG1Affine};
@@ -18,19 +19,20 @@ pub fn generate_trusted_setup(
     let s = hash_to_bls_field(&secret);
     let mut s_pow = Fr::one();
 
-    let mut s1 = Vec::with_capacity(n);
-    let mut s2 = Vec::with_capacity(n);
-    let mut s3 = Vec::with_capacity(n);
+    let mut g1_monomial_values = Vec::with_capacity(n);
+    let mut g2_monomial_values = Vec::with_capacity(n);
 
     for _ in 0..n {
-        s1.push(G1_GENERATOR.mul(&s_pow));
-        s2.push(G1_GENERATOR.mul(&s_pow)); // TODO: this should be lagrange form
-        s3.push(G2_GENERATOR.mul(&s_pow));
+        g1_monomial_values.push(MclG1::generator().mul(&s_pow));
+        g2_monomial_values.push(MclG2::generator().mul(&s_pow));
 
         s_pow = s_pow.mul(&s);
     }
 
-    (s1, s2, s3)
+    let s = MclFFTSettings::new(log2_pow2(n)).unwrap();
+    let g1_lagrange_values = s.fft_g1(&g1_monomial_values, true).unwrap();
+
+    (g1_monomial_values, g1_lagrange_values, g2_monomial_values)
 }
 
 pub(crate) static mut PRECOMPUTATION_TABLES: PrecomputationTableManager<

--- a/mcl/tests/kzg_proofs.rs
+++ b/mcl/tests/kzg_proofs.rs
@@ -2,10 +2,16 @@
 mod tests {
     use kzg_bench::tests::kzg_proofs::{
         commit_to_nil_poly, commit_to_too_long_poly_returns_err, proof_multi, proof_single,
+        trusted_setup_in_correct_form,
     };
 
     use rust_kzg_mcl::eip_7594::MclBackend;
     use rust_kzg_mcl::utils::generate_trusted_setup;
+
+    #[test]
+    pub fn test_trusted_setup_in_correct_form() {
+        trusted_setup_in_correct_form::<MclBackend>(&generate_trusted_setup);
+    }
 
     #[test]
     pub fn test_proof_single() {

--- a/zkcrypto/src/fk20_proofs.rs
+++ b/zkcrypto/src/fk20_proofs.rs
@@ -44,7 +44,7 @@ impl FK20SingleSettings<BlstFr, ZG1, ZG2, FFTSettings, PolyData, KZGSettings, ZF
 
         let mut x = Vec::new();
         for i in 0..(n - 1) {
-            x.push(ks.g1_values_lagrange_brp[n - 2 - i])
+            x.push(ks.g1_values_monomial[n - 2 - i])
         }
         x.push(G1_IDENTITY);
 
@@ -122,7 +122,7 @@ impl FK20MultiSettings<BlstFr, ZG1, ZG2, FFTSettings, PolyData, KZGSettings, ZFp
             };
             let mut j = start;
             for i in x.iter_mut().take(k - 1) {
-                i.proj = ks.g1_values_lagrange_brp[j].proj;
+                i.proj = ks.g1_values_monomial[j].proj;
                 if j >= chunk_len {
                     j -= chunk_len;
                 } else {

--- a/zkcrypto/src/kzg_types.rs
+++ b/zkcrypto/src/kzg_types.rs
@@ -934,14 +934,14 @@ impl KZGSettings<ZFr, ZG1, ZG2, ZFFTSettings, PolyData, ZFp, ZG1Affine> for ZKZG
     }
 
     fn commit_to_poly(&self, p: &PolyData) -> Result<ZG1, String> {
-        if p.coeffs.len() > self.g1_values_lagrange_brp.len() {
+        if p.coeffs.len() > self.g1_values_monomial.len() {
             return Err(String::from("Polynomial is longer than secret g1"));
         }
 
         let mut out = ZG1::default();
         g1_linear_combination(
             &mut out,
-            &self.g1_values_lagrange_brp,
+            &self.g1_values_monomial,
             &p.coeffs,
             p.coeffs.len(),
             None,

--- a/zkcrypto/tests/kzg_proofs.rs
+++ b/zkcrypto/tests/kzg_proofs.rs
@@ -2,9 +2,15 @@
 mod tests {
     use kzg_bench::tests::kzg_proofs::{
         commit_to_nil_poly, commit_to_too_long_poly_returns_err, proof_multi, proof_single,
+        trusted_setup_in_correct_form,
     };
     use rust_kzg_zkcrypto::eip_7594::ZBackend;
     use rust_kzg_zkcrypto::kzg_proofs::generate_trusted_setup;
+
+    #[test]
+    pub fn test_trusted_setup_in_correct_form() {
+        trusted_setup_in_correct_form::<ZBackend>(&generate_trusted_setup);
+    }
 
     #[test]
     fn proof_single_() {


### PR DESCRIPTION
This PR fixes #295.

The problem was that `generate_trusted_setup` function was generating trusted setup points in monomial format. Fixed it to generate in lagrange, then in all places replaced references to lagrange points with monomial.

Added tests for `generate_trusted_setup` function, in order to avoid these problems in future.